### PR TITLE
Upgrade GitHub Actions to Node.js 24 native versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,26 +5,23 @@ on:
     branches: [ main ]
   pull_request:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build and check
         run: ./gradlew :manifest-shield:check --stacktrace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,28 +7,25 @@ on:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     needs: []
     if: github.repository == 'fornewid/manifest-shield'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decrypt signing credentials
         run: release/signing-setup.sh ${{ secrets.ENCRYPT_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,13 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     # TODO: Replace permission check with `environment: release` after making repo public.
     # environment: release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check admin permission
         run: |
@@ -72,7 +69,7 @@ jobs:
           sed -i "s/VERSION_NAME=.*/VERSION_NAME=$VERSION/" manifest-shield/gradle.properties
 
       - name: Create release PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: release/${{ steps.version.outputs.version }}
           title: "Release ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `gradle/actions/setup-gradle` v4 → v5
- `peter-evans/create-pull-request` v6 → v8
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 환경변수 제거 (더 이상 불필요)

Node.js 20 deprecation 경고 해소. 2026-06-02 강제 전환 전 사전 대응.

## Test plan
- [ ] CI(build.yml) 통과 확인
- [ ] Node.js 20 deprecation 경고 미발생 확인