### PR TITLE
Use SonatypeHost.S01 instead of CENTRAL_PORTAL

### DIFF
--- a/manifest-shield/build.gradle.kts
+++ b/manifest-shield/build.gradle.kts
@@ -44,7 +44,7 @@ gradlePlugin {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+  publishToMavenCentral(SonatypeHost.S01)
   signAllPublications()
 }
 


### PR DESCRIPTION
## Summary
- Change SonatypeHost.CENTRAL_PORTAL to SonatypeHost.S01 to match existing OSSRH credentials
- CENTRAL_PORTAL requires a different token format, causing Invalid token upload errors
- S01 is consistent with naver-map-compose publishing configuration

## Test plan
- [ ] CI passes
- [ ] After merge, publish workflow succeeds with existing OSSRH credentials