### PR TITLE
Revert to SonatypeHost.CENTRAL_PORTAL

### DIFF
--- a/manifest-shield/build.gradle.kts
+++ b/manifest-shield/build.gradle.kts
@@ -44,7 +44,7 @@ gradlePlugin {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.S01)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
   signAllPublications()
 }
 


### PR DESCRIPTION
## Summary
- Revert SonatypeHost.S01 back to CENTRAL_PORTAL
- The namespace is registered on Central Portal, not OSSRH (S01 returns 402)
- Central Portal user tokens have been configured in GitHub Secrets

## Test plan
- [ ] CI passes
- [ ] After merge, publish workflow succeeds with Central Portal user tokens