### PR TITLE
Use PAT for publish workflow to bypass branch protection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     if: github.repository == 'fornewid/manifest-shield'
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle && cp .github/ci-gradle.properties ~/.gradle/gradle.properties


### PR DESCRIPTION
## Summary
- Use GH_PAT instead of GITHUB_TOKEN for checkout in publish workflow
- This allows the SNAPSHOT version bump commit to push directly to main
- GITHUB_TOKEN cannot bypass branch protection rules

## Test plan
- [ ] CI passes
- [ ] After merge, publish workflow pushes SNAPSHOT bump successfully