### PR TITLE
Enable automatic release and fix POM developer name

### DIFF
--- a/manifest-shield/build.gradle.kts
+++ b/manifest-shield/build.gradle.kts
@@ -44,7 +44,7 @@ gradlePlugin {
 }
 
 mavenPublishing {
-  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+  publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
   signAllPublications()
 }
 

--- a/manifest-shield/gradle.properties
+++ b/manifest-shield/gradle.properties
@@ -16,5 +16,5 @@ POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=fornewid
-POM_DEVELOPER_NAME=fornewid
+POM_DEVELOPER_NAME=Sungyong An
 POM_DEVELOPER_URL=https://github.com/fornewid


### PR DESCRIPTION
## Summary
- Add `automaticRelease = true` to `publishToMavenCentral` to skip manual Publish button on Central Portal
- Change `POM_DEVELOPER_NAME` from GitHub username to real name

## Test plan
- [ ] CI passes
- [ ] Next release auto-publishes without manual Publish button