### PR TITLE
Bump sample compileSdk and targetSdk to 36

### DIFF
--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace = "io.github.fornewid.manifest.shield.sample.app"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 23
-        targetSdk = 35
+        targetSdk = 36
     }
 }
 

--- a/sample/module1/build.gradle
+++ b/sample/module1/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "io.github.fornewid.manifest.shield.sample.module1"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 23
     }


### PR DESCRIPTION
## Summary
- Update compileSdk from 35 to 36 in sample app and module1
- Update targetSdk from 35 to 36 in sample app

## Test plan
- [x] Sample builds locally
- [ ] CI passes