### PR TITLE
Remove baselineMap configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ Empty categories are omitted from the output.
 | `usesNativeLibrary` | `false` | Shield `<uses-native-library>` |
 | `profileable` | `false` | Shield `<profileable>` |
 | `allowedFilter` | `{ true }` | Filter to allow/disallow entries |
-| `baselineMap` | `{ it }` | Transform entries in baseline |
 
 ## Requirements
 

--- a/manifest-shield/api/manifest-shield.api
+++ b/manifest-shield/api/manifest-shield.api
@@ -3,7 +3,6 @@ public class io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConf
 	public final fun getActivity ()Z
 	public final fun getActivityAlias ()Z
 	public final fun getAllowedFilter ()Lkotlin/jvm/functions/Function1;
-	public final fun getBaselineMap ()Lkotlin/jvm/functions/Function1;
 	public final fun getCompatibleScreens ()Z
 	public final fun getConfigurationName ()Ljava/lang/String;
 	public final fun getIntentFilter ()Z
@@ -29,7 +28,6 @@ public class io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConf
 	public final fun setActivity (Z)V
 	public final fun setActivityAlias (Z)V
 	public final fun setAllowedFilter (Lkotlin/jvm/functions/Function1;)V
-	public final fun setBaselineMap (Lkotlin/jvm/functions/Function1;)V
 	public final fun setCompatibleScreens (Z)V
 	public final fun setIntentFilter (Z)V
 	public final fun setMetaData (Z)V

--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
@@ -835,27 +835,6 @@ internal class ManifestShieldPluginTest {
         }
     }
 
-    @Test
-    fun `baselineMap transforms entries in baseline`() {
-        val pluginConfig = """
-            manifestShield {
-                configuration("release") {
-                    usesPermission = true
-                    baselineMap = { entry ->
-                        entry.contains("INTERNET") ? null : entry
-                    }
-                }
-            }
-        """.trimIndent()
-
-        AndroidProject(pluginConfig = pluginConfig).use { project ->
-            build(project, ":app:manifestShieldBaselineRelease")
-
-            val baseline = project.readBaselineFile("manifestShield/releaseAndroidManifest.txt")
-            assertThat(baseline).isNotNull()
-            assertThat(baseline).doesNotContain("INTERNET")
-        }
-    }
 
     @Test
     fun `tasks report configuration cache incompatibility gracefully`() {

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConfiguration.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConfiguration.kt
@@ -109,8 +109,4 @@ public open class ManifestShieldConfiguration @Inject constructor(
     /** Filter to determine if a manifest entry is allowed */
     @get:Input
     public var allowedFilter: (entryName: String) -> Boolean = { true }
-
-    /** Transform or remove (by returning null) entries from the baseline */
-    @get:Input
-    public var baselineMap: (entryName: String) -> String? = { it }
 }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
@@ -75,16 +75,12 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
     @get:Input
     abstract val allowedFilter: Property<(String) -> Boolean>
 
-    @get:Input
-    abstract val baselineMap: Property<(String) -> String?>
-
     @TaskAction
     internal fun execute() {
         val manifest = ManifestVisitor.parse(mergedManifestFile.get().asFile)
         val configName = configurationName.get()
         val path = projectPath.get()
         val filter = allowedFilter.get()
-        val mapper = baselineMap.get()
         val baseline = shouldBaseline.get()
         val dir = baselineDir.get()
         val prefix = filePrefix.get()
@@ -104,7 +100,7 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
             }
         }
 
-        val reportContent = buildMergedContent(manifest, mapper, showIntentFilters)
+        val reportContent = buildMergedContent(manifest, showIntentFilters)
 
         val baselineFile = OutputFileUtils.baselineFile(dir, prefix)
 
@@ -147,7 +143,6 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
 
     private fun buildMergedContent(
         manifest: ManifestExtraction,
-        baselineMap: (String) -> String?,
         showIntentFilters: Boolean,
     ): String = buildString {
         // Collect all categories with their entries
@@ -166,16 +161,16 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
 
         // Entry-based manifest-level categories
         if (guardUsesFeature.get() && manifest.usesFeature.isNotEmpty()) {
-            sections.add(Section("uses-feature", manifest.usesFeature.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("uses-feature", manifest.usesFeature.map { it.toBaselineString() }.sorted()))
         }
         if (guardUsesPermission.get() && manifest.usesPermission.isNotEmpty()) {
-            sections.add(Section("uses-permission", manifest.usesPermission.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("uses-permission", manifest.usesPermission.map { it.toBaselineString() }.sorted()))
         }
         if (guardUsesPermissionSdk23.get() && manifest.usesPermissionSdk23.isNotEmpty()) {
-            sections.add(Section("uses-permission-sdk-23", manifest.usesPermissionSdk23.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("uses-permission-sdk-23", manifest.usesPermissionSdk23.map { it.toBaselineString() }.sorted()))
         }
         if (guardPermission.get() && manifest.permission.isNotEmpty()) {
-            sections.add(Section("permission", manifest.permission.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("permission", manifest.permission.map { it.toBaselineString() }.sorted()))
         }
         if (guardSupportsScreens.get() && manifest.supportsScreens != null) {
             val lines = manifest.supportsScreens.toBaselineLines()
@@ -189,7 +184,7 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
             if (lines.isNotEmpty()) sections.add(Section("uses-configuration", lines))
         }
         if (guardSupportsGlTexture.get() && manifest.supportsGlTextures.isNotEmpty()) {
-            sections.add(Section("supports-gl-texture", manifest.supportsGlTextures.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("supports-gl-texture", manifest.supportsGlTextures.map { it.toBaselineString() }.sorted()))
         }
         if (guardQueries.get() && manifest.queries != null) {
             val lines = manifest.queries.toBaselineLines()
@@ -200,8 +195,7 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
         fun componentLines(components: List<ManifestComponent>): List<String> {
             val lines = mutableListOf<String>()
             for (comp in components.sortedBy { it.name }) {
-                val line = baselineMap(comp.toBaselineString()) ?: continue
-                lines.add(line)
+                lines.add(comp.toBaselineString())
                 if (showIntentFilters && comp.intentFilter.isNotEmpty()) {
                     for (filter in comp.intentFilter) {
                         lines.add("  intent-filter:")
@@ -227,16 +221,16 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
             sections.add(Section("receiver", componentLines(manifest.receiver)))
         }
         if (guardMetaData.get() && manifest.metaData.isNotEmpty()) {
-            sections.add(Section("meta-data", manifest.metaData.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("meta-data", manifest.metaData.map { it.toBaselineString() }.sorted()))
         }
         if (guardProvider.get() && manifest.provider.isNotEmpty()) {
             sections.add(Section("provider", componentLines(manifest.provider)))
         }
         if (guardUsesLibrary.get() && manifest.usesLibraries.isNotEmpty()) {
-            sections.add(Section("uses-library", manifest.usesLibraries.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("uses-library", manifest.usesLibraries.map { it.toBaselineString() }.sorted()))
         }
         if (guardUsesNativeLibrary.get() && manifest.usesNativeLibraries.isNotEmpty()) {
-            sections.add(Section("uses-native-library", manifest.usesNativeLibraries.mapNotNull { baselineMap(it.toBaselineString()) }.sorted()))
+            sections.add(Section("uses-native-library", manifest.usesNativeLibraries.map { it.toBaselineString() }.sorted()))
         }
         if (guardProfileable.get() && manifest.profileable != null) {
             val lines = manifest.profileable.toBaselineLines()
@@ -270,7 +264,6 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
         this.baselineDir.set(baselineDirectory)
         this.filePrefix.set(filePrefix)
         this.allowedFilter.set(config.allowedFilter)
-        this.baselineMap.set(config.baselineMap)
 
         declareCompatibilities()
     }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/sources/ManifestSourcesDiffTask.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/sources/ManifestSourcesDiffTask.kt
@@ -83,15 +83,11 @@ internal abstract class ManifestSourcesDiffTask : DefaultTask(), ShieldFlags {
     @get:Input
     abstract val filePrefix: Property<String>
 
-    @get:Input
-    abstract val baselineMap: Property<(String) -> String?>
-
     @TaskAction
     internal fun execute() {
         val manifest = ManifestVisitor.parse(mergedManifestFile.get().asFile)
         val configName = configurationName.get()
         val path = projectPath.get()
-        val mapper = baselineMap.get()
         val baseline = shouldBaseline.get()
         val dir = baselineDir.get()
         val prefix = filePrefix.get()
@@ -110,7 +106,6 @@ internal abstract class ManifestSourcesDiffTask : DefaultTask(), ShieldFlags {
         val sourcesContent = SourcesContentBuilder.buildMergedWithSdk(
             manifest = manifest,
             sourceMap = sourceMap,
-            baselineMap = mapper,
             projectPath = path,
             flags = EnabledCategories.from(this),
         )
@@ -160,8 +155,6 @@ internal abstract class ManifestSourcesDiffTask : DefaultTask(), ShieldFlags {
         applyConfig(config)
         this.baselineDir.set(baselineDirectory)
         this.filePrefix.set(filePrefix)
-        this.baselineMap.set(config.baselineMap)
-
         declareCompatibilities()
     }
 }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
@@ -11,11 +11,10 @@ internal object SourcesContentBuilder {
         entries: List<ManifestEntry>,
         elementType: String,
         sourceMap: Map<String, List<String>>,
-        baselineMap: (String) -> String?,
     ): String {
         if (sourceMap.isEmpty()) {
             return entries
-                .mapNotNull { entry -> baselineMap(entry.toBaselineString())?.let { "$it -- unknown" } }
+                .map { entry -> "${entry.toBaselineString()} -- unknown" }
                 .joinToString("\n", postfix = if (entries.isNotEmpty()) "\n" else "")
         }
 
@@ -23,7 +22,7 @@ internal object SourcesContentBuilder {
         for (entry in entries) {
             val key = "$elementType#${entry.name}"
             val sources = sourceMap[key] ?: listOf("unknown")
-            val line = baselineMap(entry.toBaselineString()) ?: continue
+            val line = entry.toBaselineString()
             for (source in sources) {
                 grouped.getOrPut(source) { mutableListOf() }.add(line)
             }
@@ -50,7 +49,6 @@ internal object SourcesContentBuilder {
     fun buildMerged(
         categories: List<Triple<String, String, List<ManifestEntry>>>,
         sourceMap: Map<String, List<String>>,
-        baselineMap: (String) -> String?,
     ): String {
         val applicationLevel = listOf("activity", "activity-alias", "service", "receiver", "provider")
 
@@ -61,7 +59,7 @@ internal object SourcesContentBuilder {
             for (entry in entries) {
                 val key = "$elementType#${entry.name}"
                 val sources = sourceMap[key] ?: listOf("unknown")
-                val line = baselineMap(entry.toBaselineString()) ?: continue
+                val line = entry.toBaselineString()
                 for (source in sources) {
                     sourceTagEntries
                         .getOrPut(source) { mutableMapOf() }
@@ -104,7 +102,6 @@ internal object SourcesContentBuilder {
     fun buildMergedWithSdk(
         manifest: ManifestExtraction,
         sourceMap: Map<String, List<String>>,
-        baselineMap: (String) -> String?,
         projectPath: String,
         flags: EnabledCategories,
     ): String {
@@ -120,7 +117,7 @@ internal object SourcesContentBuilder {
             for (entry in entries) {
                 val key = "$elementType#${entry.name}"
                 val entrySources = sourceMap[key] ?: listOf("unknown")
-                val line = baselineMap(entry.toBaselineString()) ?: continue
+                val line = entry.toBaselineString()
                 for (source in entrySources) {
                     val lines = sourceTagEntries
                         .getOrPut(source) { mutableMapOf() }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/Tasks.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/Tasks.kt
@@ -5,6 +5,6 @@ import org.gradle.api.Task
 internal object Tasks {
     fun Task.declareCompatibilities() {
         doNotTrackState("This task only outputs to console")
-        notCompatibleWithConfigurationCache("Lambda properties (allowedFilter, baselineMap) are not serializable")
+        notCompatibleWithConfigurationCache("Lambda property (allowedFilter) is not serializable")
     }
 }

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
@@ -18,7 +18,6 @@ internal class SourcesContentBuilderTest {
             entries = entries,
             elementType = "uses-permission",
             sourceMap = emptyMap(),
-            baselineMap = { it },
         )
         assertThat(result).contains("android.permission.INTERNET -- unknown")
         assertThat(result).contains("android.permission.CAMERA -- unknown")
@@ -40,7 +39,6 @@ internal class SourcesContentBuilderTest {
             entries = entries,
             elementType = "uses-permission",
             sourceMap = sourceMap,
-            baselineMap = { it },
         )
         val lines = result.lines().filter { it.isNotBlank() }
         assertThat(lines[0]).isEqualTo("app:")
@@ -64,7 +62,6 @@ internal class SourcesContentBuilderTest {
             entries = entries,
             elementType = "activity",
             sourceMap = sourceMap,
-            baselineMap = { it },
         )
         assertThat(result).contains("com.example.DetailActivity")
         assertThat(result).contains("com.example.MainActivity (exported)")
@@ -84,30 +81,9 @@ internal class SourcesContentBuilderTest {
             entries = entries,
             elementType = "activity",
             sourceMap = sourceMap,
-            baselineMap = { it },
         )
         val sourceLines = result.lines().filter { !it.startsWith("  ") && it.isNotBlank() }
         assertThat(sourceLines).containsExactly("com.a:lib:1.0:", "com.z:lib:1.0:").inOrder()
-    }
-
-    @Test
-    fun `build with baselineMap filters entries`() {
-        val entries = listOf(
-            ManifestPermission("android.permission.INTERNET"),
-            ManifestPermission("android.permission.SECRET"),
-        )
-        val sourceMap = mapOf(
-            "uses-permission#android.permission.INTERNET" to listOf("app"),
-            "uses-permission#android.permission.SECRET" to listOf("app"),
-        )
-        val result = SourcesContentBuilder.build(
-            entries = entries,
-            elementType = "uses-permission",
-            sourceMap = sourceMap,
-            baselineMap = { if (it.contains("SECRET")) null else it },
-        )
-        assertThat(result).contains("android.permission.INTERNET")
-        assertThat(result).doesNotContain("SECRET")
     }
 
     @Test
@@ -116,7 +92,6 @@ internal class SourcesContentBuilderTest {
             entries = emptyList(),
             elementType = "uses-permission",
             sourceMap = emptyMap(),
-            baselineMap = { it },
         )
         assertThat(result).isEmpty()
     }


### PR DESCRIPTION
## Summary
- Remove `baselineMap` property from `ManifestShieldConfiguration`
- `baselineMap` overlaps with `allowedFilter` and has no clear use case
- Simplifies the API surface while the project is still experimental
- Removes from: configuration, list task, sources task, content builder, tests, README, API dump

## Test plan
- [x] Unit tests pass
- [x] API dump regenerated
- [ ] CI passes