### PR TITLE
Add pull-requests read permission to Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   update_draft_release:


### PR DESCRIPTION
## Summary
- Release Drafter needs `pull-requests: read` permission to find merged PRs
- Without this, it cannot generate release notes from PR titles

## Test plan
- [ ] After merge, verify draft release is created with PR list