### PR TITLE
Remove allowedFilter and enable configuration cache compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ Empty categories are omitted from the output.
 | `usesLibrary` | `false` | Shield `<uses-library>` |
 | `usesNativeLibrary` | `false` | Shield `<uses-native-library>` |
 | `profileable` | `false` | Shield `<profileable>` |
-| `allowedFilter` | `{ true }` | Filter to allow/disallow entries |
-
 ## Requirements
 
 - Android Gradle Plugin 8.0.0+

--- a/manifest-shield/api/manifest-shield.api
+++ b/manifest-shield/api/manifest-shield.api
@@ -2,7 +2,6 @@ public class io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConf
 	public fun <init> (Ljava/lang/String;)V
 	public final fun getActivity ()Z
 	public final fun getActivityAlias ()Z
-	public final fun getAllowedFilter ()Lkotlin/jvm/functions/Function1;
 	public final fun getCompatibleScreens ()Z
 	public final fun getConfigurationName ()Ljava/lang/String;
 	public final fun getIntentFilter ()Z
@@ -27,7 +26,6 @@ public class io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConf
 	public final fun getUsesSdk ()Z
 	public final fun setActivity (Z)V
 	public final fun setActivityAlias (Z)V
-	public final fun setAllowedFilter (Lkotlin/jvm/functions/Function1;)V
 	public final fun setCompatibleScreens (Z)V
 	public final fun setIntentFilter (Z)V
 	public final fun setMetaData (Z)V

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConfiguration.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldConfiguration.kt
@@ -105,8 +105,4 @@ public open class ManifestShieldConfiguration @Inject constructor(
     /** Enable source-attributed format grouped by library/module origin */
     @get:Input
     public var sources: Boolean = false
-
-    /** Filter to determine if a manifest entry is allowed */
-    @get:Input
-    public var allowedFilter: (entryName: String) -> Boolean = { true }
 }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
@@ -15,7 +15,6 @@ import io.github.fornewid.gradle.plugins.manifestshield.internal.utils.Messaging
 import io.github.fornewid.gradle.plugins.manifestshield.internal.utils.OutputFileUtils
 import io.github.fornewid.gradle.plugins.manifestshield.internal.utils.Tasks.declareCompatibilities
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestComponent
-import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestEntry
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
@@ -72,33 +71,15 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
     @get:Input
     abstract val filePrefix: Property<String>
 
-    @get:Input
-    abstract val allowedFilter: Property<(String) -> Boolean>
-
     @TaskAction
     internal fun execute() {
         val manifest = ManifestVisitor.parse(mergedManifestFile.get().asFile)
         val configName = configurationName.get()
         val path = projectPath.get()
-        val filter = allowedFilter.get()
         val baseline = shouldBaseline.get()
         val dir = baselineDir.get()
         val prefix = filePrefix.get()
         val showIntentFilters = guardIntentFilter.get()
-
-        // Check for disallowed entries across all entry categories
-        val entryCategories = collectEntryCategories(manifest)
-        for ((category, entries) in entryCategories) {
-            val disallowed = entries.filter { !filter(it.name) }
-            if (disallowed.isNotEmpty()) {
-                throw GradleException(buildString {
-                    appendLine("Disallowed manifest entries found in $path ($configName/$category):")
-                    disallowed.forEach { appendLine("  \"${it.name}\"") }
-                    appendLine()
-                    appendLine("These entries must be removed based on the configured 'allowedFilter'.")
-                })
-            }
-        }
 
         val reportContent = buildMergedContent(manifest, showIntentFilters)
 
@@ -126,19 +107,6 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
             is NoDiff -> logger.debug(result.noDiffMessage)
             is BaselineCreated -> logger.lifecycle(result.baselineCreatedMessage(withColor = true))
         }
-    }
-
-    private fun collectEntryCategories(manifest: ManifestExtraction): List<Pair<String, List<ManifestEntry>>> {
-        val entries = mutableListOf<Pair<String, List<ManifestEntry>>>()
-        if (guardUsesFeature.get()) entries.add("uses-feature" to manifest.usesFeature)
-        if (guardUsesPermission.get()) entries.add("uses-permission" to manifest.usesPermission)
-        if (guardPermission.get()) entries.add("permission" to manifest.permission)
-        if (guardActivity.get()) entries.add("activity" to manifest.activity)
-        if (guardActivityAlias.get()) entries.add("activity-alias" to manifest.activityAlias)
-        if (guardService.get()) entries.add("service" to manifest.service)
-        if (guardReceiver.get()) entries.add("receiver" to manifest.receiver)
-        if (guardProvider.get()) entries.add("provider" to manifest.provider)
-        return entries
     }
 
     private fun buildMergedContent(
@@ -263,7 +231,6 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
         applyConfig(config)
         this.baselineDir.set(baselineDirectory)
         this.filePrefix.set(filePrefix)
-        this.allowedFilter.set(config.allowedFilter)
 
         declareCompatibilities()
     }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/Tasks.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/Tasks.kt
@@ -5,6 +5,5 @@ import org.gradle.api.Task
 internal object Tasks {
     fun Task.declareCompatibilities() {
         doNotTrackState("This task only outputs to console")
-        notCompatibleWithConfigurationCache("Lambda property (allowedFilter) is not serializable")
     }
 }


### PR DESCRIPTION
## Summary
- Remove `allowedFilter` lambda property — baseline diff already detects unwanted changes
- Remove `notCompatibleWithConfigurationCache()` — no more non-serializable properties
- Remove `collectEntryCategories()` helper that was only used by allowedFilter
- Plugin is now compatible with Gradle configuration cache

## Test plan
- [x] Unit tests pass
- [x] API dump regenerated
- [ ] CI passes
- [ ] Configuration cache test passes