### PR TITLE
Clean up root build.gradle and sample app config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,4 +11,3 @@ allprojects {
         mavenCentral()
     }
 }
-

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -21,6 +21,5 @@ dependencies {
 manifestShield {
     configuration("release") {
         sources = true
-        metaData = true
     }
 }

--- a/sample/app/manifestShield/releaseAndroidManifest.sources.txt
+++ b/sample/app/manifestShield/releaseAndroidManifest.sources.txt
@@ -8,9 +8,6 @@ uses-permission:
 activity:
   io.github.fornewid.manifest.shield.sample.app.MainActivity (exported)
 
-meta-data:
-  com.example.FEATURE_FLAG (true)
-
 [:sample:module1]
 uses-permission:
   android.permission.ACCESS_NETWORK_STATE

--- a/sample/app/manifestShield/releaseAndroidManifest.txt
+++ b/sample/app/manifestShield/releaseAndroidManifest.txt
@@ -7,6 +7,3 @@ uses-permission:
 
 activity:
   io.github.fornewid.manifest.shield.sample.app.MainActivity (exported)
-
-meta-data:
-  com.example.FEATURE_FLAG (true)


### PR DESCRIPTION
## Summary
- Remove trailing blank line from root build.gradle (leftover from signing code removal)
- Remove `metaData = true` opt-in from sample app config
- Regenerate sample baselines without meta-data entries

## Test plan
- [x] Sample baselines regenerated
- [ ] CI passes