### PR TITLE
Pass signing credentials to publishPlugins step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,9 @@ jobs:
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
 
       - name: Create git tag
         if: ${{ !endsWith(steps.version.outputs.version, '-SNAPSHOT') }}


### PR DESCRIPTION
## Summary
- `publishPlugins` runs as a separate Gradle invocation and needs signing credentials
- Without them, signing task fails with 'no configured signatory'
- Add `signingInMemoryKey*` env vars to the Plugin Portal publish step

## Test plan
- [ ] Next release publishes to Plugin Portal successfully