### PR TITLE
Show android:permission on exported components

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,13 @@ uses-permission:
 
 activity:
   io.github.fornewid.manifest.shield.sample.app.MainActivity (exported)
+
+service:
+  io.github.fornewid.manifest.shield.sample.app.BoundService (exported)
+    permission: android.permission.BIND_JOB_SERVICE
 ```
+
+Permission attributes (`android:permission`, `android:readPermission`, `android:writePermission`) are shown as indented lines below exported components.
 
 **releaseAndroidManifest.sources.txt** — grouped by source module/library (when `sources = true`):
 

--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
@@ -166,6 +166,19 @@ internal class ManifestShieldPluginTest {
             </manifest>
         """.trimIndent()
 
+        private val MANIFEST_WITH_PERMISSION_COMPONENT = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application>
+                    <activity android:name=".MainActivity" android:exported="true" />
+                    <service android:name=".BoundService" android:exported="true"
+                        android:permission="android.permission.BIND_JOB_SERVICE" />
+                    <service android:name=".InternalService" android:exported="false"
+                        android:permission="com.example.INTERNAL" />
+                </application>
+            </manifest>
+        """.trimIndent()
+
         private val MANIFEST_WITH_MIXED_EXPORTED = """
             <?xml version="1.0" encoding="utf-8"?>
             <manifest xmlns:android="http://schemas.android.com/apk/res/android">
@@ -898,6 +911,23 @@ internal class ManifestShieldPluginTest {
             assertThat(baseline).isNotNull()
             assertThat(baseline).contains("ExportedService")
             assertThat(baseline).contains("InternalService")
+        }
+    }
+
+    @Test
+    fun `baseline shows permission on exported components`() {
+        AndroidProject().use { project ->
+            project.updateManifest(MANIFEST_WITH_PERMISSION_COMPONENT)
+
+            build(project, ":app:manifestShieldBaselineRelease")
+
+            val baseline = project.readBaselineFile("manifestShield/releaseAndroidManifest.txt")
+            assertThat(baseline).isNotNull()
+            assertThat(baseline).contains("service:")
+            assertThat(baseline).contains("BoundService (exported)")
+            assertThat(baseline).contains("  permission: android.permission.BIND_JOB_SERVICE")
+            // InternalService is exported=false, so its permission should not appear
+            assertThat(baseline).doesNotContain("com.example.INTERNAL")
         }
     }
 

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
@@ -228,6 +228,7 @@ internal object ManifestVisitor {
                         else -> null
                     },
                     targetActivity = targetActivity,
+                    permission = node.attrNS("permission"),
                     intentFilter = node.parseIntentFilters(),
                 )
             }
@@ -249,6 +250,9 @@ internal object ManifestVisitor {
                         else -> null
                     },
                     authorities = node.attrNS("authorities"),
+                    permission = node.attrNS("permission"),
+                    readPermission = node.attrNS("readPermission"),
+                    writePermission = node.attrNS("writePermission"),
                 )
             }
             .distinct().sortedBy { it.name }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/list/ManifestShieldListTask.kt
@@ -181,6 +181,9 @@ internal abstract class ManifestShieldListTask : DefaultTask(), ShieldFlags {
             val lines = mutableListOf<String>()
             for (comp in filtered.sortedBy { it.name }) {
                 lines.add(comp.toBaselineString())
+                for (permLine in comp.permissionLines()) {
+                    lines.add("  $permLine")
+                }
                 if (showIntentFilters && comp.intentFilter.isNotEmpty()) {
                     for (filter in comp.intentFilter) {
                         lines.add("  intent-filter:")

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
@@ -123,6 +123,11 @@ internal object SourcesContentBuilder {
                         .getOrPut(source) { mutableMapOf() }
                         .getOrPut(tag) { mutableListOf() }
                     lines.add(line)
+                    if (isComponent && entry is ManifestComponent) {
+                        for (permLine in entry.permissionLines()) {
+                            lines.add("  $permLine")
+                        }
+                    }
                     if (isComponent && guardIntentFilter && entry is ManifestComponent && entry.intentFilter.isNotEmpty()) {
                         for (filter in entry.intentFilter) {
                             lines.add("  intent-filter:")

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestComponent.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestComponent.kt
@@ -6,6 +6,9 @@ internal data class ManifestComponent(
     val exported: Boolean?,
     val targetActivity: String? = null,
     val authorities: String? = null,
+    val permission: String? = null,
+    val readPermission: String? = null,
+    val writePermission: String? = null,
     val intentFilter: List<IntentFilterInfo> = emptyList(),
 ) : ManifestEntry {
 
@@ -20,6 +23,16 @@ internal data class ManifestComponent(
         if (targetActivity != null) {
             append(" -> $targetActivity")
         }
+    }
+
+    /** Permission lines for exported components (indented format). */
+    fun permissionLines(): List<String> {
+        if (exported != true) return emptyList()
+        val lines = mutableListOf<String>()
+        permission?.let { lines.add("permission: $it") }
+        readPermission?.let { lines.add("readPermission: $it") }
+        writePermission?.let { lines.add("writePermission: $it") }
+        return lines
     }
 }
 

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestComponentTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestComponentTest.kt
@@ -49,4 +49,56 @@ internal class ManifestComponentTest {
         )
         assertThat(component.toBaselineString()).isEqualTo("com.example.ShortcutAlias (exported) -> com.example.MainActivity")
     }
+
+    @Test
+    fun `permissionLines with exported and permission`() {
+        val component = ManifestComponent(
+            name = "com.example.MyService", type = ComponentType.SERVICE,
+            exported = true, permission = "android.permission.BIND_JOB_SERVICE",
+        )
+        assertThat(component.permissionLines()).containsExactly("permission: android.permission.BIND_JOB_SERVICE")
+    }
+
+    @Test
+    fun `permissionLines with non-exported returns empty`() {
+        val component = ManifestComponent(
+            name = "com.example.MyService", type = ComponentType.SERVICE,
+            exported = false, permission = "android.permission.BIND_JOB_SERVICE",
+        )
+        assertThat(component.permissionLines()).isEmpty()
+    }
+
+    @Test
+    fun `permissionLines with null exported returns empty`() {
+        val component = ManifestComponent(
+            name = "com.example.MyService", type = ComponentType.SERVICE,
+            exported = null, permission = "android.permission.BIND_JOB_SERVICE",
+        )
+        assertThat(component.permissionLines()).isEmpty()
+    }
+
+    @Test
+    fun `permissionLines with provider readPermission and writePermission`() {
+        val component = ManifestComponent(
+            name = "com.example.MyProvider", type = ComponentType.PROVIDER,
+            exported = true,
+            permission = "android.permission.READ_CONTACTS",
+            readPermission = "android.permission.READ_CONTACTS",
+            writePermission = "android.permission.WRITE_CONTACTS",
+        )
+        assertThat(component.permissionLines()).containsExactly(
+            "permission: android.permission.READ_CONTACTS",
+            "readPermission: android.permission.READ_CONTACTS",
+            "writePermission: android.permission.WRITE_CONTACTS",
+        ).inOrder()
+    }
+
+    @Test
+    fun `permissionLines with exported but no permission returns empty`() {
+        val component = ManifestComponent(
+            name = "com.example.MyActivity", type = ComponentType.ACTIVITY,
+            exported = true,
+        )
+        assertThat(component.permissionLines()).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary

- Parse `android:permission`, `android:readPermission`, and `android:writePermission` attributes on components
- Display permission attributes as indented lines below exported components in the baseline output
- Non-exported components never show permission (no security significance)
- Applied to both list task and sources task output

## Output format

```
service:
  BoundService (exported)
    permission: android.permission.BIND_JOB_SERVICE
  InternalService

provider:
  MyProvider (exported, authorities=com.example.provider)
    permission: android.permission.READ_CONTACTS
    readPermission: android.permission.READ_CONTACTS
    writePermission: android.permission.WRITE_CONTACTS
```

## Breaking Change

Exported components with `android:permission` will now have additional indented lines in the baseline. Existing baselines may need re-generation.

## Test plan

- [ ] Unit tests for `permissionLines()` (exported/non-exported/null, provider read/write)
- [ ] `baseline shows permission on exported components` gradleTest
- [ ] All existing tests pass

Closes #32

Generated with [Claude Code](https://claude.com/claude-code)