### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## $(date +%Y-%m-%d) - Fix XML External Entity (XXE) vulnerability
+**Vulnerability:** XML External Entity (XXE) vulnerability in `DocumentBuilderFactory` used to parse `AndroidManifest.xml` files.
+**Learning:** By default, Java's `DocumentBuilderFactory` allows external entities and DOCTYPE declarations, which can be exploited to read local files (XXE) or perform SSRF if an attacker can control the XML content being parsed. While `AndroidManifest.xml` files usually come from trusted sources, a malicious or compromised dependency could provide a crafted manifest that exploits this when the plugin merges manifests.
+**Prevention:** Always explicitly configure `DocumentBuilderFactory` to disable DOCTYPE declarations (`http://apache.org/xml/features/disallow-doctype-decl`), external general/parameter entities, and external DTDs. Also, set `isXIncludeAware` and `isExpandEntityReferences` to `false`.

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
@@ -48,6 +48,12 @@ internal object ManifestVisitor {
     fun parse(manifestFile: File): ManifestExtraction {
         val factory = DocumentBuilderFactory.newInstance().apply {
             isNamespaceAware = true
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            isXIncludeAware = false
+            isExpandEntityReferences = false
         }
         val doc = factory.newDocumentBuilder().parse(manifestFile)
         val root = doc.documentElement


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: XML External Entity (XXE) vulnerability in `ManifestVisitor.kt`.
🎯 Impact: Attackers could potentially read local files or perform SSRF if they manage to supply a malicious `AndroidManifest.xml` (e.g. via a compromised dependency).
🔧 Fix: Explicitly disabled DOCTYPE declarations, external general/parameter entities, and external DTDs in the `DocumentBuilderFactory` used to parse manifests.
✅ Verification: Ran `./gradlew test` to ensure parsing functionality still works. Also confirmed via test scripts that XXE parsing now fails as expected.

---
*PR created automatically by Jules for task [3390417101667142279](https://jules.google.com/task/3390417101667142279) started by @fornewid*