### PR TITLE
Bind release-drafter publish to the actual pushed tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,5 +17,14 @@ jobs:
       - uses: release-drafter/release-drafter@v6
         with:
           publish: ${{ startsWith(github.ref, 'refs/tags/') }}
+          # When publish.yml pushes a tag we want the GitHub Release to be
+          # bound to that exact tag, not whatever release-drafter computes
+          # from `$NEXT_PATCH_VERSION`. Without this override the template
+          # is re-evaluated at publish time, which produces a phantom tag
+          # whenever the actual release isn't a +1 patch from the previous
+          # one (e.g. minor or major bumps, or the very first release on a
+          # repo with no prior tags).
+          tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background

While cutting `proguard-shield` 0.0.1 ([fornewid/proguard-shield#10](https://github.com/fornewid/proguard-shield/pull/10)) we hit a release-drafter bug. publish.yml correctly tagged 0.0.1 and uploaded to Maven Central + Plugin Portal, but the GitHub Release ended up bound to a phantom `0.1.1` tag.

## Root cause

`release-drafter.yml` sets `tag-template: '$NEXT_PATCH_VERSION'`. When release-drafter runs on a tag push with `publish: true`, it re-evaluates that template at publish time. If the pushed tag is not a +1 patch from the most recent release — for example on a fresh repo with no prior tags, or on a minor/major bump — release-drafter mints a different tag and binds the release to it instead of the tag publish.yml just pushed.

## Why manifest-shield hasn't hit this

manifest-shield has only ever cut `+1 patch` releases inside the same `0.1.x` series, so `$NEXT_PATCH_VERSION` always coincides with the tag publish.yml pushed. The bug is latent. The first time the project bumps to `0.2.0` (or `1.0.0`), the GitHub Release would attach to a phantom tag.

## Fix

Override `tag` and `name` on the release-drafter step only when the workflow runs on a tag push. The pushed tag is the source of truth; the template-driven name is still used for plain main-push (draft-update) runs.

```yaml
- uses: release-drafter/release-drafter@v6
  with:
    publish: ${{ startsWith(github.ref, 'refs/tags/') }}
    tag:  ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
    name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
```

## Test plan

- [x] 9-line workflow change, no behaviour change for the existing patch-release flow
- [ ] CI green on this PR
- [ ] Verify on the next real release that the GitHub Release sits on the correct tag
