### PR TITLE
Fix false source attribution for singleton manifest elements

### DIFF
--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
@@ -1147,6 +1147,47 @@ internal class ManifestShieldPluginTest {
 
 
     @Test
+    fun `sources baseline attributes app-declared queries to project module`() {
+        val pluginConfig = """
+            manifestShield {
+                configuration("release") {
+                    queries = true
+                    sources = true
+                }
+            }
+        """.trimIndent()
+
+        val manifestWithQueries = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <queries>
+                    <package android:name="com.example.helper" />
+                </queries>
+                <application>
+                    <activity android:name=".MainActivity" android:exported="true" />
+                </application>
+            </manifest>
+        """.trimIndent()
+
+        AndroidProject(
+            manifestContent = manifestWithQueries,
+            pluginConfig = pluginConfig,
+        ).use { project ->
+            build(project, ":app:manifestShieldBaselineRelease")
+
+            val sources = project.readBaselineFile("manifestShield/releaseAndroidManifest.sources.txt")
+            assertThat(sources).isNotNull()
+            // The :app group must contain the queries the app itself declared.
+            val appSection = sources!!.substringAfter("[:app]").substringBefore("\n[")
+            assertThat(appSection).contains("queries:")
+            assertThat(appSection).contains("package: com.example.helper")
+            // The placeholder "<unresolved>" group must NOT appear when blame log
+            // resolves the source successfully.
+            assertThat(sources).doesNotContain("[<unresolved>]")
+        }
+    }
+
+    @Test
     fun `baseline task works with configuration cache`() {
         AndroidProject().use { project ->
             val result = build(

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParser.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParser.kt
@@ -4,7 +4,8 @@ import java.io.File
 
 internal data class BlameEntry(
     val elementType: String,
-    val elementName: String,
+    /** `null` for singleton elements that have no `android:name` (e.g. `uses-sdk`, `queries`). */
+    val elementName: String?,
     val source: String,
 )
 
@@ -50,8 +51,9 @@ internal object BlameLogParser {
                 continue
             }
 
-            // Try to match action lines for current element (collect ALL sources, not just first)
-            if (currentElementType != null && currentElementName != null) {
+            // Try to match action lines for current element (collect ALL sources, not just first).
+            // Singleton elements have a null name and are still attributed via their type alone.
+            if (currentElementType != null) {
                 // Match: ADDED/INJECTED/MERGED/IMPLIED/CONVERTED from [library] /path
                 val bracketedMatch = ACTION_FROM_BRACKETED.find(line)
                 if (bracketedMatch != null) {
@@ -99,13 +101,17 @@ internal object BlameLogParser {
 
     /**
      * Build a map from element key to list of sources.
+     *
+     * - Name-keyed elements use `"$type#$name"` as the key (e.g. `uses-permission#android.permission.INTERNET`).
+     * - Singleton elements with no `android:name` (e.g. `uses-sdk`, `queries`) use `type` alone.
+     *
      * Each element may have multiple sources (e.g., ADDED from app + MERGED from library).
      * Duplicate sources for the same element are deduplicated.
      */
     fun buildSourceMap(entries: List<BlameEntry>): Map<String, List<String>> {
         val map = mutableMapOf<String, MutableList<String>>()
         for (entry in entries) {
-            val key = "${entry.elementType}#${entry.elementName}"
+            val key = entry.elementName?.let { "${entry.elementType}#$it" } ?: entry.elementType
             val sources = map.getOrPut(key) { mutableListOf() }
             if (entry.source !in sources) {
                 sources.add(entry.source)

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
@@ -19,14 +19,14 @@ internal object SourcesContentBuilder {
     ): String {
         if (sourceMap.isEmpty()) {
             return entries
-                .map { entry -> "${entry.toBaselineString()} -- unknown" }
+                .map { entry -> "${entry.toBaselineString()} -- $UNRESOLVED_SOURCE" }
                 .joinToString("\n", postfix = if (entries.isNotEmpty()) "\n" else "")
         }
 
         val grouped = mutableMapOf<String, MutableList<String>>()
         for (entry in entries) {
             val key = "$elementType#${entry.name}"
-            val sources = sourceMap[key] ?: listOf("unknown")
+            val sources = sourceMap[key] ?: listOf(UNRESOLVED_SOURCE)
             val line = entry.toBaselineString()
             for (source in sources) {
                 grouped.getOrPut(source) { mutableListOf() }.add(line)
@@ -69,7 +69,7 @@ internal object SourcesContentBuilder {
         fun addEntries(tag: String, elementType: String, entries: List<ManifestEntry>, isComponent: Boolean = false) {
             for (entry in entries) {
                 val key = "$elementType#${entry.name}"
-                val entrySources = sourceMap[key] ?: listOf("unknown")
+                val entrySources = sourceMap[key] ?: listOf(UNRESOLVED_SOURCE)
                 val line = entry.toBaselineString()
                 for (source in entrySources) {
                     val lines = sourceTagEntries

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
@@ -5,8 +5,12 @@ import io.github.fornewid.gradle.plugins.manifestshield.internal.ManifestExtract
 import io.github.fornewid.gradle.plugins.manifestshield.internal.STARTUP_PROVIDER_NAME
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestComponent
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestEntry
+import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestQuery
 
 internal object SourcesContentBuilder {
+
+    /** Group label for elements whose source the parser could not resolve. */
+    const val UNRESOLVED_SOURCE: String = "<unresolved>"
 
     fun build(
         entries: List<ManifestEntry>,
@@ -120,32 +124,39 @@ internal object SourcesContentBuilder {
         if (flags.usesLibrary && libList.isNotEmpty()) addEntries("uses-library", "uses-library", libList)
         if (flags.usesNativeLibrary && manifest.usesNativeLibraries.isNotEmpty()) addEntries("uses-native-library", "uses-native-library", manifest.usesNativeLibraries)
 
-        // Non-ManifestEntry elements (attributed to the current project module)
-        fun addProjectLines(tag: String, lines: List<String>) {
-            if (lines.isNotEmpty()) {
+        // Singleton elements have no android:name, so the blame log keys them by type alone.
+        // We resolve their source via sourceMap[elementType] instead of attributing them all
+        // to the current project. If parsing ever misses a source, the entry surfaces under
+        // the [<unresolved>] group rather than being silently misattributed to :app.
+        fun addSingletonEntries(tag: String, elementType: String, lines: List<String>) {
+            if (lines.isEmpty()) return
+            val sources = sourceMap[elementType] ?: listOf(UNRESOLVED_SOURCE)
+            for (source in sources) {
                 sourceTagEntries
-                    .getOrPut(projectPath) { mutableMapOf() }
+                    .getOrPut(source) { mutableMapOf() }
                     .getOrPut(tag) { mutableListOf() }
                     .addAll(lines)
             }
         }
         if (flags.supportsScreens && manifest.supportsScreens != null) {
-            addProjectLines("supports-screens", manifest.supportsScreens.toBaselineLines())
+            addSingletonEntries("supports-screens", "supports-screens", manifest.supportsScreens.toBaselineLines())
         }
         if (flags.compatibleScreens && manifest.compatibleScreens.isNotEmpty()) {
-            addProjectLines("compatible-screens", manifest.compatibleScreens)
+            addSingletonEntries("compatible-screens", "compatible-screens", manifest.compatibleScreens)
         }
         if (flags.usesConfiguration && manifest.usesConfiguration != null) {
-            addProjectLines("uses-configuration", manifest.usesConfiguration.toBaselineLines())
+            addSingletonEntries("uses-configuration", "uses-configuration", manifest.usesConfiguration.toBaselineLines())
         }
         if (flags.queries && manifest.queries != null) {
-            addProjectLines("queries", manifest.queries.toBaselineLines())
+            addQueriesEntries(manifest.queries, sourceMap, sourceTagEntries)
         }
         if (flags.profileable && manifest.profileable != null) {
-            addProjectLines("profileable", manifest.profileable.toBaselineLines())
+            addSingletonEntries("profileable", "profileable", manifest.profileable.toBaselineLines())
         }
 
-        // Startup initializers (attributed to the current project module)
+        // Startup initializers are <meta-data> children of androidx.startup's InitializationProvider,
+        // declared by libraries that hook into App Startup. They are not directly traceable through
+        // the merged blame log entries, so they remain attributed to the current project module.
         if (flags.startup && manifest.startupInitializers.isNotEmpty()) {
             sourceTagEntries
                 .getOrPut(projectPath) { mutableMapOf() }
@@ -153,49 +164,88 @@ internal object SourcesContentBuilder {
                 .addAll(manifest.startupInitializers)
         }
 
-        // uses-sdk is always from the current project module
-        val sdk = manifest.usesSdk
-        if (flags.usesSdk && sdk != null) {
-            sourceTagEntries.getOrPut(projectPath) { mutableMapOf() }
+        // uses-sdk: AGP injects this from build.gradle's minSdk/targetSdk, which the blame log
+        // records as `INJECTED from <app>/AndroidManifest.xml`, so it resolves to the project
+        // path naturally via sourceMap.
+        if (flags.usesSdk && manifest.usesSdk != null) {
+            addSingletonEntries("uses-sdk", "uses-sdk", manifest.usesSdk.toBaselineLines())
         }
 
-        val sortedSources = sourceTagEntries.keys.sorted().let { sources ->
+        // Group order: local modules (`:`-prefixed), then external libraries, then <unresolved>
+        // last so reviewers see it as an exception rather than a normal source.
+        val sortedSources = sourceTagEntries.keys.let { sources ->
             val local = sources.filter { it.startsWith(":") }.sorted()
-            val external = sources.filter { !it.startsWith(":") }.sorted()
-            local + external
+            val unresolved = sources.filter { it == UNRESOLVED_SOURCE }
+            val external = (sources - local.toSet() - unresolved.toSet()).sorted()
+            local + external + unresolved
         }
+
+        val manifestLevelOrder = listOf(
+            "uses-sdk", "uses-feature", "uses-permission", "uses-permission-sdk-23", "permission",
+            "supports-screens", "compatible-screens", "uses-configuration", "supports-gl-texture", "queries"
+        )
 
         return buildString {
             for ((sourceIdx, source) in sortedSources.withIndex()) {
                 appendLine("[$source]")
                 val tagMap = sourceTagEntries[source] ?: continue
 
-                // uses-sdk is per-source "app" only (it comes from the build config)
-                val hasSdk = flags.usesSdk && source == projectPath && manifest.usesSdk != null
-
-                val manifestTags = mutableListOf<String>()
-                if (hasSdk) manifestTags.add("uses-sdk")
-                manifestTags.addAll(listOf("uses-feature", "uses-permission", "uses-permission-sdk-23", "permission",
-                    "supports-screens", "compatible-screens", "uses-configuration", "supports-gl-texture", "queries").filter { it in tagMap })
-
-                val appTags = applicationLevel.filter { it in tagMap }
-                val allTags = manifestTags + appTags
+                val allTags = manifestLevelOrder.filter { it in tagMap } +
+                    applicationLevel.filter { it in tagMap }
 
                 for ((i, tag) in allTags.withIndex()) {
-                    if (tag == "uses-sdk") {
-                        appendLine("uses-sdk:")
-                        manifest.usesSdk?.minSdkVersion?.let { appendLine("  minSdkVersion=$it") }
-                        manifest.usesSdk?.targetSdkVersion?.let { appendLine("  targetSdkVersion=$it") }
-                    } else {
-                        appendLine("$tag:")
-                        tagMap[tag]?.forEach { appendLine("  $it") }
-                    }
+                    appendLine("$tag:")
+                    tagMap[tag]?.forEach { appendLine("  $it") }
                     if (i < allTags.size - 1) appendLine()
                 }
 
                 if (sourceIdx < sortedSources.size - 1) {
                     appendLine()
                 }
+            }
+        }
+    }
+
+    /**
+     * Attribute the contents of a `<queries>` block. Unlike other singleton elements,
+     * `<queries>` is a container whose children (`<package>`, `<provider>`, `<intent>`)
+     * each carry independent sources in the manifest-merger blame log.
+     *
+     * - `<package>`: keyed by `package#$name` in the blame log → resolved per package.
+     * - `<provider>` and `<intent>`: child-level keys in the blame log are inconsistent
+     *   (providers may use authorities, intents are composite), so they are attributed
+     *   to the first source of the enclosing `<queries>` container as a best-effort.
+     *   Per-child resolution for these two is tracked as a follow-up.
+     */
+    private fun addQueriesEntries(
+        queries: ManifestQuery,
+        sourceMap: Map<String, List<String>>,
+        sourceTagEntries: MutableMap<String, MutableMap<String, MutableList<String>>>,
+    ) {
+        fun addLine(source: String, line: String) {
+            sourceTagEntries
+                .getOrPut(source) { mutableMapOf() }
+                .getOrPut("queries") { mutableListOf() }
+                .add(line)
+        }
+
+        queries.packages.sorted().forEach { name ->
+            val sources = sourceMap["package#$name"] ?: listOf(UNRESOLVED_SOURCE)
+            for (source in sources) {
+                addLine(source, "package: $name")
+            }
+        }
+
+        if (queries.providers.isNotEmpty() || queries.intents.isNotEmpty()) {
+            val containerSource = sourceMap["queries"]?.firstOrNull() ?: UNRESOLVED_SOURCE
+            queries.providers.sorted().forEach { auth ->
+                addLine(containerSource, "provider: $auth")
+            }
+            queries.intents.forEach { intent ->
+                addLine(containerSource, "intent:")
+                intent.actions.forEach { addLine(containerSource, "  action: $it") }
+                intent.categories.forEach { addLine(containerSource, "  category: $it") }
+                intent.dataSpecs.forEach { addLine(containerSource, "  data: $it") }
             }
         }
     }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestSdk.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestSdk.kt
@@ -4,8 +4,9 @@ internal data class ManifestSdk(
     val minSdkVersion: String?,
     val targetSdkVersion: String?,
 ) {
-    fun toBaselineLines(): List<String> = buildList {
-        minSdkVersion?.let { add("minSdkVersion=$it") }
-        targetSdkVersion?.let { add("targetSdkVersion=$it") }
-    }
+    // `buildList` (Kotlin 1.6+) is intentionally avoided; project targets language version 1.4.
+    fun toBaselineLines(): List<String> = listOfNotNull(
+        minSdkVersion?.let { "minSdkVersion=$it" },
+        targetSdkVersion?.let { "targetSdkVersion=$it" },
+    )
 }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestSdk.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestSdk.kt
@@ -3,4 +3,9 @@ package io.github.fornewid.gradle.plugins.manifestshield.models
 internal data class ManifestSdk(
     val minSdkVersion: String?,
     val targetSdkVersion: String?,
-)
+) {
+    fun toBaselineLines(): List<String> = buildList {
+        minSdkVersion?.let { add("minSdkVersion=$it") }
+        targetSdkVersion?.let { add("targetSdkVersion=$it") }
+    }
+}

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParserTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParserTest.kt
@@ -123,9 +123,12 @@ internal class BlameLogParserTest {
         }
         assertThat(firebaseService.source).isEqualTo("com.google.firebase:firebase-common:20.0.0")
 
-        // Elements without a name (like uses-sdk) are skipped by the parser
+        // Singleton elements (no android:name) are still attributed by element type alone.
+        // uses-sdk in this fixture is `INJECTED from <app>/AndroidManifest.xml`.
         val sdk = entries.filter { it.elementType == "uses-sdk" }
-        assertThat(sdk).isEmpty()
+        assertThat(sdk).hasSize(1)
+        assertThat(sdk.single().elementName).isNull()
+        assertThat(sdk.single().source).isEqualTo(":app")
 
         // Both ADDED and IMPLIED actions for MainActivity should be parsed
         val mainActivityEntries = entries.filter {
@@ -133,6 +136,60 @@ internal class BlameLogParserTest {
         }
         assertThat(mainActivityEntries).hasSize(2)
         assertThat(mainActivityEntries.map { it.source }).containsExactly(":app", ":app")
+    }
+
+    @Test
+    fun `parse captures singleton elements by element type alone`() {
+        val singletonsLog = File(javaClass.classLoader.getResource("test-blame-log-singletons.txt")!!.toURI())
+        val rootDir = File("/Users/dev/MyApp")
+        val entries = BlameLogParser.parse(singletonsLog, rootDir)
+
+        // uses-sdk: AGP-injected from the app manifest, single source
+        val sdk = entries.filter { it.elementType == "uses-sdk" }
+        assertThat(sdk).hasSize(1)
+        assertThat(sdk.single().elementName).isNull()
+        assertThat(sdk.single().source).isEqualTo(":app")
+
+        // queries: declared by app AND merged from a library — two sources
+        val queries = entries.filter { it.elementType == "queries" }
+        assertThat(queries).hasSize(2)
+        assertThat(queries.map { it.source }).containsExactly(
+            ":app",
+            "com.google.android.gms:play-services-base:18.5.0",
+        )
+
+        // supports-screens: app-only
+        val supportsScreens = entries.filter { it.elementType == "supports-screens" }
+        assertThat(supportsScreens).hasSize(1)
+        assertThat(supportsScreens.single().source).isEqualTo(":app")
+
+        // compatible-screens: library-only
+        val compatibleScreens = entries.filter { it.elementType == "compatible-screens" }
+        assertThat(compatibleScreens).hasSize(1)
+        assertThat(compatibleScreens.single().source).isEqualTo("com.example:legacy-screens:1.0.0")
+
+        // uses-configuration / profileable: app-only
+        assertThat(entries.filter { it.elementType == "uses-configuration" }.map { it.source })
+            .containsExactly(":app")
+        assertThat(entries.filter { it.elementType == "profileable" }.map { it.source })
+            .containsExactly(":app")
+    }
+
+    @Test
+    fun `buildSourceMap keys singleton elements by type alone`() {
+        val singletonsLog = File(javaClass.classLoader.getResource("test-blame-log-singletons.txt")!!.toURI())
+        val rootDir = File("/Users/dev/MyApp")
+        val entries = BlameLogParser.parse(singletonsLog, rootDir)
+        val sourceMap = BlameLogParser.buildSourceMap(entries)
+
+        assertThat(sourceMap["uses-sdk"]).containsExactly(":app")
+        assertThat(sourceMap["queries"])
+            .containsExactly(":app", "com.google.android.gms:play-services-base:18.5.0")
+        assertThat(sourceMap["compatible-screens"])
+            .containsExactly("com.example:legacy-screens:1.0.0")
+
+        // Name-keyed elements still use the "$type#$name" key
+        assertThat(sourceMap["package#com.example.helper"]).containsExactly(":app")
     }
 
     @Test

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 internal class SourcesContentBuilderTest {
 
     @Test
-    fun `build with empty source map appends unknown`() {
+    fun `build with empty source map appends unresolved marker`() {
         val entries = listOf(
             ManifestPermission("android.permission.INTERNET"),
             ManifestPermission("android.permission.CAMERA"),
@@ -24,8 +24,8 @@ internal class SourcesContentBuilderTest {
             elementType = "uses-permission",
             sourceMap = emptyMap(),
         )
-        assertThat(result).contains("android.permission.INTERNET -- unknown")
-        assertThat(result).contains("android.permission.CAMERA -- unknown")
+        assertThat(result).contains("android.permission.INTERNET -- <unresolved>")
+        assertThat(result).contains("android.permission.CAMERA -- <unresolved>")
     }
 
     @Test

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
@@ -1,9 +1,14 @@
 package io.github.fornewid.gradle.plugins.manifestshield.internal.utils
 
 import com.google.common.truth.Truth.assertThat
+import io.github.fornewid.gradle.plugins.manifestshield.internal.EnabledCategories
+import io.github.fornewid.gradle.plugins.manifestshield.internal.ManifestExtraction
 import io.github.fornewid.gradle.plugins.manifestshield.models.ComponentType
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestComponent
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestPermission
+import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestProfileable
+import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestQuery
+import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestSdk
 import org.junit.jupiter.api.Test
 
 internal class SourcesContentBuilderTest {
@@ -95,4 +100,205 @@ internal class SourcesContentBuilderTest {
         )
         assertThat(result).isEmpty()
     }
+
+    @Test
+    fun `buildMergedWithSdk attributes singleton elements via sourceMap`() {
+        val manifest = emptyManifest().copy(
+            usesSdk = ManifestSdk(minSdkVersion = "23", targetSdkVersion = "36"),
+            profileable = ManifestProfileable(shell = true, enabled = null),
+        )
+        val sourceMap = mapOf(
+            "uses-sdk" to listOf(":app"),
+            "profileable" to listOf("com.example:profiler:1.0.0"),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = sourceMap,
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        assertThat(result).contains("[:app]")
+        assertThat(result).contains("uses-sdk:")
+        assertThat(result).contains("  minSdkVersion=23")
+        assertThat(result).contains("  targetSdkVersion=36")
+        assertThat(result).contains("[com.example:profiler:1.0.0]")
+        // profileable is attributed to the library, NOT to :app
+        val appSection = result.substringAfter("[:app]").substringBefore("[com.")
+        assertThat(appSection).doesNotContain("profileable:")
+    }
+
+    @Test
+    fun `buildMergedWithSdk attributes queries packages per child`() {
+        // App declares <queries><package="com.example.helper"/></queries>.
+        // Library injects <queries><package="com.google.android.gms"/></queries>.
+        // Merged manifest has both packages, but each has its own blame entry.
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = listOf("com.example.helper", "com.google.android.gms"),
+                intents = emptyList(),
+                providers = emptyList(),
+            ),
+        )
+        val sourceMap = mapOf(
+            "queries" to listOf(":app", "com.google.android.gms:play-services-base:18.5.0"),
+            "package#com.example.helper" to listOf(":app"),
+            "package#com.google.android.gms" to listOf("com.google.android.gms:play-services-base:18.5.0"),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = sourceMap,
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        val appSection = result.substringAfter("[:app]").substringBefore("[com.")
+        val librarySection = result.substringAfter("[com.google.android.gms:play-services-base:18.5.0]")
+
+        // helper appears under :app only
+        assertThat(appSection).contains("package: com.example.helper")
+        assertThat(librarySection).doesNotContain("package: com.example.helper")
+        // gms appears under the library only
+        assertThat(librarySection).contains("package: com.google.android.gms")
+        assertThat(appSection).doesNotContain("package: com.google.android.gms")
+    }
+
+    @Test
+    fun `buildMergedWithSdk falls back to unresolved when query package source is missing`() {
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = listOf("com.unknown"),
+                intents = emptyList(),
+                providers = emptyList(),
+            ),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = emptyMap(),
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        assertThat(result).contains("[<unresolved>]")
+        val unresolvedSection = result.substringAfter("[<unresolved>]")
+        assertThat(unresolvedSection).contains("queries:")
+        assertThat(unresolvedSection).contains("package: com.unknown")
+    }
+
+    @Test
+    fun `buildMergedWithSdk places unresolved group last when other sources exist`() {
+        val manifest = emptyManifest().copy(
+            usesSdk = ManifestSdk(minSdkVersion = "23", targetSdkVersion = null),
+            queries = ManifestQuery(
+                packages = listOf("com.resolved", "com.missing"),
+                intents = emptyList(),
+                providers = emptyList(),
+            ),
+        )
+        val sourceMap = mapOf(
+            "uses-sdk" to listOf(":app"),
+            "package#com.resolved" to listOf("com.example:lib:1.0.0"),
+            // package#com.missing is intentionally missing → routed to <unresolved>
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = sourceMap,
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        // Local module (`:app`) appears first, external library next, <unresolved> last
+        val appIdx = result.indexOf("[:app]")
+        val libIdx = result.indexOf("[com.example:lib:1.0.0]")
+        val unresolvedIdx = result.indexOf("[<unresolved>]")
+        assertThat(appIdx).isAtLeast(0)
+        assertThat(libIdx).isGreaterThan(appIdx)
+        assertThat(unresolvedIdx).isGreaterThan(libIdx)
+    }
+
+    @Test
+    fun `buildMergedWithSdk uses unresolved group when sourceMap misses singleton`() {
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = listOf("com.unknown"),
+                intents = emptyList(),
+                providers = emptyList(),
+            ),
+        )
+        // sourceMap is empty — simulating a parser miss for the queries element
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = emptyMap(),
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        assertThat(result).contains("[<unresolved>]")
+        // <unresolved> sorts last
+        assertThat(result.indexOf("[<unresolved>]")).isAtLeast(0)
+    }
+
+    @Test
+    fun `buildMergedWithSdk does not silently route singletons to projectPath`() {
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = listOf("com.from.library"),
+                intents = emptyList(),
+                providers = emptyList(),
+            ),
+        )
+        val sourceMap = mapOf(
+            "queries" to listOf("com.example:lib:1.0.0"),
+            "package#com.from.library" to listOf("com.example:lib:1.0.0"),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = sourceMap,
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        // queries should appear ONLY under the library group, not under [:app]
+        assertThat(result).doesNotContain("[:app]")
+        assertThat(result).contains("[com.example:lib:1.0.0]")
+        assertThat(result).contains("queries:")
+    }
+
+    private fun emptyManifest() = ManifestExtraction(
+        usesSdk = null,
+        usesPermission = emptyList(),
+        usesPermissionSdk23 = emptyList(),
+        permission = emptyList(),
+        usesFeature = emptyList(),
+        supportsScreens = null,
+        compatibleScreens = emptyList(),
+        usesConfiguration = null,
+        supportsGlTextures = emptyList(),
+        queries = null,
+        activity = emptyList(),
+        activityAlias = emptyList(),
+        metaData = emptyList(),
+        service = emptyList(),
+        receiver = emptyList(),
+        provider = emptyList(),
+        usesLibraries = emptyList(),
+        usesNativeLibraries = emptyList(),
+        profileable = null,
+        startupInitializers = emptyList(),
+    )
+
+    private fun enableSingletons() = EnabledCategories(
+        usesSdk = true, usesFeature = false, usesPermission = false, usesPermissionSdk23 = false,
+        permission = false, supportsScreens = true, compatibleScreens = true, usesConfiguration = true,
+        supportsGlTexture = false, queries = true, activity = false, activityAlias = false,
+        metaData = false, service = false, receiver = false, provider = false,
+        usesLibrary = false, usesNativeLibrary = false, profileable = true, intentFilter = false,
+        startup = false, exportedOnly = true, requiredOnly = true, unprotectedOnly = true,
+    )
 }

--- a/manifest-shield/src/test/resources/test-blame-log-singletons.txt
+++ b/manifest-shield/src/test/resources/test-blame-log-singletons.txt
@@ -1,0 +1,28 @@
+-- Merging decision tree log ---
+manifest
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:2:1-30:12
+INJECTED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:2:1-30:12
+	package
+		INJECTED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml
+uses-sdk
+INJECTED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml reason: use-sdk injection requested
+queries
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:7:5-9:15
+MERGED from [com.google.android.gms:play-services-base:18.5.0] /Users/dev/.gradle/caches/8.10.2/transforms/abc/transformed/play-services-base-18.5.0/AndroidManifest.xml:5:5-9:15
+package#com.example.helper
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:8:9-54
+package#com.google.android.gms
+ADDED from [com.google.android.gms:play-services-base:18.5.0] /Users/dev/.gradle/caches/8.10.2/transforms/abc/transformed/play-services-base-18.5.0/AndroidManifest.xml:6:9-65
+supports-screens
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:11:5-15:40
+compatible-screens
+MERGED from [com.example:legacy-screens:1.0.0] /Users/dev/.gradle/caches/8.10.2/transforms/def/transformed/legacy-screens-1.0.0/AndroidManifest.xml:8:5-12:40
+uses-configuration
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:17:5-19:44
+application
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:21:5-29:19
+INJECTED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:21:5-29:19
+profileable
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:36:9-45
+activity#com.example.app.MainActivity
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:25:9-32:20


### PR DESCRIPTION
Closes #71.

## Summary

In `sources=true` mode, singleton manifest elements (those without an `android:name` — `<queries>`, `<supports-screens>`, `<uses-configuration>`, `<profileable>`, `<compatible-screens>`, `<uses-sdk>`) were silently routed to the project module group regardless of their actual origin. A library injecting `<queries>` would appear in the baseline as if the app had declared it, weakening the most actionable signal in source-grouped diff review.

This change resolves their sources via the manifest-merger blame log instead of falling back to the project path.

### Parser (`BlameLogParser`)

- `BlameEntry.elementName` is now nullable; the `currentElementName != null` guard that previously dropped source lines for name-less elements is removed.
- `buildSourceMap` keys name-less entries by element type alone (e.g. `"queries"`), and name-keyed entries by `"$type#$name"` as before.

### Builder (`SourcesContentBuilder`)

- New `addSingletonEntries(tag, elementType, lines)` resolves source via `sourceMap[elementType]`. The previous silent project-path fallback is gone.
- `<uses-sdk>` is unified with the rest — AGP records it as `INJECTED from <app>/AndroidManifest.xml`, so it resolves naturally to the project group.
- `<queries>` is a container whose children carry independent sources. New `addQueriesEntries` attributes `<package>` children per name via `sourceMap[package#$name]`. `<provider>` and `<intent>` children fall back to the enclosing container's first source as a best-effort; per-child resolution for those two is a follow-up.
- A new `[<unresolved>]` group surfaces entries the parser could not attribute, sorted last. In practice it should never appear in shipped baselines — if it does, it indicates a parser gap rather than a silent misattribution.

## Migration

Baselines may shift singleton entries from `[:app]` to library groups (or vice versa) on the next regeneration. The contents are unchanged; only the source group moves to reflect the actual origin. Affected users should run `./gradlew manifestShieldBaseline` once.

## Test plan

- [x] `./gradlew :manifest-shield:test` — 96 unit tests pass (9 added)
- [x] `./gradlew :manifest-shield:gradleTest` — gradleTest pass (1 e2e added)
- [x] `./gradlew :manifest-shield:check` — full check pass
- [x] Manually verified blame-log format for all singleton element types using the sample app
- [ ] CI green
