### PR TITLE
Add cross-version gradleTest smoke tests against AGP 9.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ The following manifest elements are **not tracked** by this plugin:
 
 ## Requirements
 
-- Android Gradle Plugin 8.0.0+
-- Gradle 8.0+
+- Android Gradle Plugin 8.0.0+ (verified through AGP 9.1.x)
+- Gradle 8.0+ — must satisfy your AGP version's own minimum (e.g., AGP 9.1.x requires Gradle 9.3.1+)
+- JDK 17+ — required by AGP 8.0+ regardless of plugin version
 
 ## AI Agent Guide
 

--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginAgp9Test.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginAgp9Test.kt
@@ -1,0 +1,119 @@
+package io.github.fornewid.gradle.plugins.manifestshield
+
+import com.google.common.truth.Truth.assertThat
+import io.github.fornewid.gradle.plugins.manifestshield.fixture.AndroidProject
+import io.github.fornewid.gradle.plugins.manifestshield.fixture.Builder.build
+import io.github.fornewid.gradle.plugins.manifestshield.fixture.Builder.buildAndFail
+import org.gradle.api.JavaVersion
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Cross-version smoke tests against AGP 9.x to guard against regressions
+ * introduced by AGP API or manifest-merger changes. The companion test class
+ * [ManifestShieldPluginTest] still exercises full coverage on the minimum
+ * supported AGP (8.5.0).
+ */
+internal class ManifestShieldPluginAgp9Test {
+
+    @BeforeEach
+    fun requireJava17() {
+        // AGP 9.x and Gradle 9.3.1 require JDK 17+; skip on older JVMs to avoid
+        // a confusing TestKit failure when run locally on JDK 11.
+        assumeTrue(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17))
+    }
+
+    private fun newProject(
+        pluginConfig: String = AndroidProject.DEFAULT_PLUGIN_CONFIG,
+    ) = AndroidProject(
+        pluginConfig = pluginConfig,
+        agpVersion = AGP_VERSION,
+        gradleVersion = GRADLE_VERSION,
+    )
+
+    @Test
+    fun `baseline task creates merged baseline file on AGP 9`() {
+        newProject().use { project ->
+            val result = build(project, ":app:manifestShieldBaselineRelease")
+
+            assertThat(result.output).contains("Manifest Shield baseline created")
+
+            val baseline = project.readBaselineFile("manifestShield/releaseAndroidManifest.txt")
+            assertThat(baseline).isNotNull()
+            assertThat(baseline).contains("uses-permission:")
+            assertThat(baseline).contains("android.permission.INTERNET")
+            assertThat(baseline).contains("activity:")
+            assertThat(baseline).contains("MainActivity")
+            assertThat(baseline).contains("(exported)")
+        }
+    }
+
+    @Test
+    fun `guard task fails when permission is added on AGP 9`() {
+        newProject().use { project ->
+            build(project, ":app:manifestShieldBaselineRelease")
+
+            project.updateManifest(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                    <uses-permission android:name="android.permission.INTERNET" />
+                    <uses-permission android:name="android.permission.CAMERA" />
+                    <application>
+                        <activity
+                            android:name=".MainActivity"
+                            android:exported="true">
+                            <intent-filter>
+                                <action android:name="android.intent.action.MAIN" />
+                                <category android:name="android.intent.category.LAUNCHER" />
+                            </intent-filter>
+                        </activity>
+                    </application>
+                </manifest>
+                """.trimIndent()
+            )
+
+            val result = buildAndFail(project, ":app:manifestShieldRelease")
+            assertThat(result.output).contains("android.permission.CAMERA")
+        }
+    }
+
+    @Test
+    fun `sources baseline parses AGP 9 blame log`() {
+        val pluginConfig = """
+            manifestShield {
+                configuration("release") {
+                    sources = true
+                }
+            }
+        """.trimIndent()
+
+        newProject(pluginConfig = pluginConfig).use { project ->
+            val result = build(project, ":app:manifestShieldSourcesBaselineRelease")
+            assertThat(result.output).contains("Manifest Shield baseline created")
+
+            val sources = project.readBaselineFile("manifestShield/releaseAndroidManifest.sources.txt")
+            assertThat(sources).isNotNull()
+            assertThat(sources).contains("[:app]")
+        }
+    }
+
+    @Test
+    fun `configuration cache is stored on AGP 9`() {
+        newProject().use { project ->
+            val result = build(
+                project,
+                ":app:manifestShieldBaselineRelease",
+                "--configuration-cache",
+            )
+            assertThat(result.output).contains("Manifest Shield baseline created")
+            assertThat(result.output).contains("Configuration cache entry stored")
+        }
+    }
+
+    private companion object {
+        const val AGP_VERSION = "9.1.0"
+        const val GRADLE_VERSION = "9.3.1"
+    }
+}

--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/fixture/AndroidProject.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/fixture/AndroidProject.kt
@@ -7,6 +7,8 @@ internal class AndroidProject(
     private val manifestContent: String = DEFAULT_MANIFEST,
     private val pluginConfig: String = DEFAULT_PLUGIN_CONFIG,
     private val androidExtra: String = "",
+    val agpVersion: String = DEFAULT_AGP_VERSION,
+    val gradleVersion: String? = null,
 ) : AutoCloseable {
 
     val dir: File = File("build/gradleTest/${UUID.randomUUID()}").apply { mkdirs() }
@@ -33,7 +35,7 @@ internal class AndroidProject(
                     mavenCentral()
                 }
                 dependencies {
-                    classpath 'com.android.tools.build:gradle:8.5.0'
+                    classpath 'com.android.tools.build:gradle:$agpVersion'
                     classpath files('$escapedJar')
                 }
             }
@@ -117,6 +119,8 @@ internal class AndroidProject(
     }
 
     companion object {
+        const val DEFAULT_AGP_VERSION = "8.5.0"
+
         val DEFAULT_MANIFEST = """
             <?xml version="1.0" encoding="utf-8"?>
             <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/fixture/Builder.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/fixture/Builder.kt
@@ -24,5 +24,6 @@ internal object Builder {
         // Plugin JAR is injected via buildscript classpath in the test project.
         withProjectDir(project.dir)
         withArguments(args.toList() + "-s")
+        project.gradleVersion?.let { withGradleVersion(it) }
     }
 }


### PR DESCRIPTION
## Summary
- Parameterize `agpVersion` and `gradleVersion` on the `AndroidProject` test fixture so each `gradleTest` can target a specific AGP / Gradle pair via `GradleRunner.withGradleVersion`. Default remains AGP 8.5.0, preserving existing coverage.
- Add `ManifestShieldPluginAgp9Test` with four smoke tests against AGP 9.1.0 + Gradle 9.3.1 (baseline generation, guard failure on added permission, sources blame-log parsing, configuration cache stored). Skipped on JDK below 17 via `Assumptions.assumeTrue`.
- Clarify `Requirements` in README: JDK 17+ is the baseline (mandated by AGP 8.0+ regardless of plugin version) and the Gradle floor tracks the AGP version's own minimum.

## Test plan
- [x] `./gradlew :manifest-shield:check` — unit tests + AGP 8.5.0 gradleTest + AGP 9.1.0 gradleTest all pass
- [x] Manual sample-app verification on AGP 9.1.0 + Gradle 9.3.1: `manifestShieldBaseline`, `manifestShield`, configuration cache store/reuse all work; baseline output unchanged from AGP 8.8.0
- [ ] CI green
