### PR TITLE
Attribute <queries><intent> children per intent

### DIFF
--- a/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
+++ b/manifest-shield/src/gradleTest/kotlin/io/github/fornewid/gradle/plugins/manifestshield/ManifestShieldPluginTest.kt
@@ -1188,6 +1188,54 @@ internal class ManifestShieldPluginTest {
     }
 
     @Test
+    fun `sources baseline attributes queries intents per child to project module`() {
+        val pluginConfig = """
+            manifestShield {
+                configuration("release") {
+                    queries = true
+                    sources = true
+                }
+            }
+        """.trimIndent()
+
+        val manifestWithIntents = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <queries>
+                    <intent>
+                        <action android:name="android.intent.action.SEND" />
+                        <data android:mimeType="image/*" />
+                    </intent>
+                    <intent>
+                        <action android:name="android.intent.action.VIEW" />
+                        <data android:scheme="https" />
+                    </intent>
+                </queries>
+                <application>
+                    <activity android:name=".MainActivity" android:exported="true" />
+                </application>
+            </manifest>
+        """.trimIndent()
+
+        AndroidProject(
+            manifestContent = manifestWithIntents,
+            pluginConfig = pluginConfig,
+        ).use { project ->
+            build(project, ":app:manifestShieldBaselineRelease")
+
+            val sources = project.readBaselineFile("manifestShield/releaseAndroidManifest.sources.txt")
+            assertThat(sources).isNotNull()
+            // Both intents the app declared land under :app and disambiguate by action.
+            val appSection = sources!!.substringAfter("[:app]").substringBefore("\n[")
+            assertThat(appSection).contains("queries:")
+            assertThat(appSection).contains("action: android.intent.action.SEND")
+            assertThat(appSection).contains("action: android.intent.action.VIEW")
+            // No fallback group: the parser resolved every blame key.
+            assertThat(sources).doesNotContain("[<unresolved>]")
+        }
+    }
+
+    @Test
     fun `baseline task works with configuration cache`() {
         AndroidProject().use { project ->
             val result = build(

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
@@ -375,31 +375,49 @@ internal object ManifestVisitor {
      *
      *     intent#action:name:$action[+category:name:$cat][+data:$attr:$value]
      *
-     * The attribute order (action → category → data) and the use of the *first*
-     * non-empty data attribute mirror what AGP records in the blame log. Verified
-     * for the single-data case; multi-data cases inside one `<intent>` may not
-     * round-trip exactly, in which case the lookup falls back to `<unresolved>`
-     * downstream rather than misattributing.
+     * The attribute order (action → category → data) mirrors AGP. Across all
+     * `<data>` children of one `<intent>`, AGP records *one* `data:` segment
+     * derived from the first non-empty data attribute it sees, so we match that
+     * single-segment shape rather than emitting one segment per `<data>` element.
+     * Direct-child traversal avoids the recursive `getElementsByTagName` matches
+     * (per style guide).
      */
     private fun parseQueryIntent(intentNode: Element): QueryIntent {
-        val info = parseIntentContent(intentNode)
+        val actionNodes = intentNode.directChildElements("action")
+        val categoryNodes = intentNode.directChildElements("category")
+        val dataNodes = intentNode.directChildElements("data")
+
+        val actions = actionNodes.mapNotNull { it.attrNS("name") }.sorted()
+        val categories = categoryNodes.mapNotNull { it.attrNS("name") }.sorted()
+        val dataSpecs = dataNodes
+            .map { data ->
+                buildDataSpec(
+                    data.attrNS("scheme") ?: "", data.attrNS("host") ?: "",
+                    data.attrNS("port") ?: "", data.attrNS("path") ?: "",
+                    data.attrNS("pathPrefix") ?: "", data.attrNS("pathPattern") ?: "",
+                    data.attrNS("mimeType") ?: "",
+                )
+            }
+            .filter { it.isNotBlank() }.sorted()
 
         val keyParts = mutableListOf<String>()
-        intentNode.directChildElements("action").forEach { node ->
+        actionNodes.forEach { node ->
             node.attrNS("name")?.let { keyParts.add("action:name:$it") }
         }
-        intentNode.directChildElements("category").forEach { node ->
+        categoryNodes.forEach { node ->
             node.attrNS("name")?.let { keyParts.add("category:name:$it") }
         }
-        intentNode.directChildElements("data").forEach { node ->
-            firstDataAttribute(node)?.let { (attr, value) -> keyParts.add("data:$attr:$value") }
-        }
+        dataNodes.asSequence()
+            .mapNotNull { firstDataAttribute(it) }
+            .firstOrNull()
+            ?.let { (attr, value) -> keyParts.add("data:$attr:$value") }
+
         val blameKey = if (keyParts.isEmpty()) "intent" else "intent#" + keyParts.joinToString("+")
 
         return QueryIntent(
-            actions = info.actions,
-            categories = info.categories,
-            dataSpecs = info.dataSpecs,
+            actions = actions,
+            categories = categories,
+            dataSpecs = dataSpecs,
             blameKey = blameKey,
         )
     }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitor.kt
@@ -11,6 +11,7 @@ import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestPermissio
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestProfileable
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestQuery
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestSdk
+import io.github.fornewid.gradle.plugins.manifestshield.models.QueryIntent
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestSupportsScreens
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestUsesConfiguration
 import java.io.File
@@ -120,7 +121,7 @@ internal object ManifestVisitor {
                 val packages = node.getElementsByTagName("package").toElementList()
                     .mapNotNull { it.attrNS("name") }
                 val intents = node.directChildElements("intent")
-                    .map { intentNode -> parseIntentContent(intentNode) }
+                    .map { intentNode -> parseQueryIntent(intentNode) }
                 val providers = node.getElementsByTagName("provider").toElementList()
                     .mapNotNull { it.attrNS("authorities") }
                 ManifestQuery(packages = packages, intents = intents, providers = providers)
@@ -366,6 +367,62 @@ internal object ManifestVisitor {
             }
             .filter { it.isNotBlank() }.sorted()
         return IntentFilterInfo(actions = actions, categories = categories, dataSpecs = dataSpecs)
+    }
+
+    /**
+     * Parse an `<intent>` child of `<queries>` and synthesize the AGP manifest-merger
+     * blame-log key alongside the display fields. The key takes the form:
+     *
+     *     intent#action:name:$action[+category:name:$cat][+data:$attr:$value]
+     *
+     * The attribute order (action → category → data) and the use of the *first*
+     * non-empty data attribute mirror what AGP records in the blame log. Verified
+     * for the single-data case; multi-data cases inside one `<intent>` may not
+     * round-trip exactly, in which case the lookup falls back to `<unresolved>`
+     * downstream rather than misattributing.
+     */
+    private fun parseQueryIntent(intentNode: Element): QueryIntent {
+        val info = parseIntentContent(intentNode)
+
+        val keyParts = mutableListOf<String>()
+        intentNode.directChildElements("action").forEach { node ->
+            node.attrNS("name")?.let { keyParts.add("action:name:$it") }
+        }
+        intentNode.directChildElements("category").forEach { node ->
+            node.attrNS("name")?.let { keyParts.add("category:name:$it") }
+        }
+        intentNode.directChildElements("data").forEach { node ->
+            firstDataAttribute(node)?.let { (attr, value) -> keyParts.add("data:$attr:$value") }
+        }
+        val blameKey = if (keyParts.isEmpty()) "intent" else "intent#" + keyParts.joinToString("+")
+
+        return QueryIntent(
+            actions = info.actions,
+            categories = info.categories,
+            dataSpecs = info.dataSpecs,
+            blameKey = blameKey,
+        )
+    }
+
+    /**
+     * AGP records `<data>` in the blame-log key by its first non-empty attribute.
+     * `pathSuffix` and `pathAdvancedPattern` were introduced in API 31; including
+     * them keeps the synthesized key consistent with manifests that use the newer
+     * matching attributes.
+     * [attrNS] already returns null for blank values, so we only need to walk the
+     * priority order until something resolves.
+     */
+    private fun firstDataAttribute(dataNode: Element): Pair<String, String>? {
+        val order = listOf(
+            "scheme", "host", "port",
+            "path", "pathPrefix", "pathPattern", "pathSuffix", "pathAdvancedPattern",
+            "mimeType",
+        )
+        for (attr in order) {
+            val value = dataNode.attrNS(attr)
+            if (value != null) return attr to value
+        }
+        return null
     }
 
     /** Get direct child elements by tag name (non-recursive, unlike getElementsByTagName) */

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilder.kt
@@ -212,10 +212,13 @@ internal object SourcesContentBuilder {
      * each carry independent sources in the manifest-merger blame log.
      *
      * - `<package>`: keyed by `package#$name` in the blame log → resolved per package.
-     * - `<provider>` and `<intent>`: child-level keys in the blame log are inconsistent
-     *   (providers may use authorities, intents are composite), so they are attributed
-     *   to the first source of the enclosing `<queries>` container as a best-effort.
-     *   Per-child resolution for these two is tracked as a follow-up.
+     * - `<intent>`: keyed by a composite of action/category/data attributes (synthesized
+     *   in [io.github.fornewid.gradle.plugins.manifestshield.models.QueryIntent.blameKey])
+     *   → resolved per intent.
+     * - `<provider>`: AGP rejects multi-source `<queries><provider>` with conflicting
+     *   authorities at merge time, so a single-source declaration is the only buildable
+     *   case. Attributed to the enclosing `<queries>` container's first source, which
+     *   is necessarily the one source that declared the provider.
      */
     private fun addQueriesEntries(
         queries: ManifestQuery,
@@ -236,16 +239,20 @@ internal object SourcesContentBuilder {
             }
         }
 
-        if (queries.providers.isNotEmpty() || queries.intents.isNotEmpty()) {
+        queries.intents.forEach { intent ->
+            val sources = sourceMap[intent.blameKey] ?: listOf(UNRESOLVED_SOURCE)
+            for (source in sources) {
+                addLine(source, "intent:")
+                intent.actions.forEach { addLine(source, "  action: $it") }
+                intent.categories.forEach { addLine(source, "  category: $it") }
+                intent.dataSpecs.forEach { addLine(source, "  data: $it") }
+            }
+        }
+
+        if (queries.providers.isNotEmpty()) {
             val containerSource = sourceMap["queries"]?.firstOrNull() ?: UNRESOLVED_SOURCE
             queries.providers.sorted().forEach { auth ->
                 addLine(containerSource, "provider: $auth")
-            }
-            queries.intents.forEach { intent ->
-                addLine(containerSource, "intent:")
-                intent.actions.forEach { addLine(containerSource, "  action: $it") }
-                intent.categories.forEach { addLine(containerSource, "  category: $it") }
-                intent.dataSpecs.forEach { addLine(containerSource, "  data: $it") }
             }
         }
     }

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestQuery.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestQuery.kt
@@ -2,7 +2,7 @@ package io.github.fornewid.gradle.plugins.manifestshield.models
 
 internal data class ManifestQuery(
     val packages: List<String>,
-    val intents: List<IntentFilterInfo>,
+    val intents: List<QueryIntent>,
     val providers: List<String>,
 ) {
     fun toBaselineLines(): List<String> {

--- a/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/QueryIntent.kt
+++ b/manifest-shield/src/main/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/QueryIntent.kt
@@ -1,0 +1,17 @@
+package io.github.fornewid.gradle.plugins.manifestshield.models
+
+/**
+ * One `<intent>` child of a `<queries>` block.
+ *
+ * Unlike [IntentFilterInfo] (used by `<activity>` etc.), this carries the
+ * synthesized AGP manifest-merger blame-log key so that the source-grouped
+ * baseline can attribute each intent to the module or library that injected
+ * it. AGP keys queries-level intents with a composite of the form
+ * `intent#action:name:$action[+category:name:$cat][+data:$attr:$value]`.
+ */
+internal data class QueryIntent(
+    val actions: List<String>,
+    val categories: List<String>,
+    val dataSpecs: List<String>,
+    val blameKey: String,
+)

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParserTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/BlameLogParserTest.kt
@@ -176,6 +176,18 @@ internal class BlameLogParserTest {
     }
 
     @Test
+    fun `parse captures composite blame keys for queries-level intents`() {
+        val singletonsLog = File(javaClass.classLoader.getResource("test-blame-log-singletons.txt")!!.toURI())
+        val rootDir = File("/Users/dev/MyApp")
+        val sourceMap = BlameLogParser.buildSourceMap(BlameLogParser.parse(singletonsLog, rootDir))
+
+        assertThat(sourceMap["intent#action:name:android.intent.action.SEND+data:mimeType:image/*"])
+            .containsExactly(":app")
+        assertThat(sourceMap["intent#action:name:android.intent.action.PICK"])
+            .containsExactly("com.example:lib:1.0.0")
+    }
+
+    @Test
     fun `buildSourceMap keys singleton elements by type alone`() {
         val singletonsLog = File(javaClass.classLoader.getResource("test-blame-log-singletons.txt")!!.toURI())
         val rootDir = File("/Users/dev/MyApp")

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitorEdgeCaseTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitorEdgeCaseTest.kt
@@ -123,4 +123,63 @@ internal class ManifestVisitorEdgeCaseTest {
         assertThat(result.usesFeature[0].required).isTrue()
         assertThat(result.usesFeature[0].toBaselineString()).isEqualTo("android.hardware.camera (required)")
     }
+
+    @Test
+    fun `parse synthesizes blame keys for queries-level intents matching AGP format`() {
+        // Reproduces the exact composite-key shape AGP records in
+        // manifest-merger-<variant>-report.txt for <queries><intent> children.
+        val manifest = tempDir.resolve("manifest.xml").apply {
+            writeText("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                    package="com.example">
+                    <queries>
+                        <intent>
+                            <action android:name="android.intent.action.SEND" />
+                            <data android:mimeType="image/*" />
+                        </intent>
+                        <intent>
+                            <action android:name="android.intent.action.VIEW" />
+                            <data android:scheme="https" />
+                        </intent>
+                        <intent>
+                            <action android:name="android.intent.action.PICK" />
+                        </intent>
+                    </queries>
+                </manifest>
+            """.trimIndent())
+        }
+        val result = ManifestVisitor.parse(manifest)
+
+        val keys = result.queries!!.intents.map { it.blameKey }
+        assertThat(keys).containsExactly(
+            "intent#action:name:android.intent.action.SEND+data:mimeType:image/*",
+            "intent#action:name:android.intent.action.VIEW+data:scheme:https",
+            "intent#action:name:android.intent.action.PICK",
+        ).inOrder()
+    }
+
+    @Test
+    fun `parse picks the first non-empty data attribute for the intent blame key`() {
+        // AGP records only the first non-empty data attribute in the composite key,
+        // following the order scheme → host → port → path → pathPrefix → pathPattern → mimeType.
+        val manifest = tempDir.resolve("manifest.xml").apply {
+            writeText("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                    package="com.example">
+                    <queries>
+                        <intent>
+                            <action android:name="android.intent.action.VIEW" />
+                            <data android:scheme="https" android:host="example.com" />
+                        </intent>
+                    </queries>
+                </manifest>
+            """.trimIndent())
+        }
+        val result = ManifestVisitor.parse(manifest)
+
+        assertThat(result.queries!!.intents.single().blameKey)
+            .isEqualTo("intent#action:name:android.intent.action.VIEW+data:scheme:https")
+    }
 }

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitorEdgeCaseTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/ManifestVisitorEdgeCaseTest.kt
@@ -160,6 +160,36 @@ internal class ManifestVisitorEdgeCaseTest {
     }
 
     @Test
+    fun `parse emits a single data segment even when intent has multiple data children`() {
+        // AGP records only one `data:` segment per <intent> in the blame-log key,
+        // derived from the first non-empty data attribute across all <data> children.
+        // Naive per-data emission would produce a key AGP never records → mismatch.
+        val manifest = tempDir.resolve("manifest.xml").apply {
+            writeText("""
+                <?xml version="1.0" encoding="utf-8"?>
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                    package="com.example">
+                    <queries>
+                        <intent>
+                            <action android:name="android.intent.action.VIEW" />
+                            <data android:scheme="https" />
+                            <data android:mimeType="image/*" />
+                        </intent>
+                    </queries>
+                </manifest>
+            """.trimIndent())
+        }
+        val result = ManifestVisitor.parse(manifest)
+
+        // Only one data segment in the key (from the first <data> child),
+        // but both data specs surface in the display output.
+        val intent = result.queries!!.intents.single()
+        assertThat(intent.blameKey)
+            .isEqualTo("intent#action:name:android.intent.action.VIEW+data:scheme:https")
+        assertThat(intent.dataSpecs).hasSize(2)
+    }
+
+    @Test
     fun `parse picks the first non-empty data attribute for the intent blame key`() {
         // AGP records only the first non-empty data attribute in the composite key,
         // following the order scheme → host → port → path → pathPrefix → pathPattern → mimeType.

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/internal/utils/SourcesContentBuilderTest.kt
@@ -9,6 +9,7 @@ import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestPermissio
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestProfileable
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestQuery
 import io.github.fornewid.gradle.plugins.manifestshield.models.ManifestSdk
+import io.github.fornewid.gradle.plugins.manifestshield.models.QueryIntent
 import org.junit.jupiter.api.Test
 
 internal class SourcesContentBuilderTest {
@@ -186,6 +187,82 @@ internal class SourcesContentBuilderTest {
         val unresolvedSection = result.substringAfter("[<unresolved>]")
         assertThat(unresolvedSection).contains("queries:")
         assertThat(unresolvedSection).contains("package: com.unknown")
+    }
+
+    @Test
+    fun `buildMergedWithSdk attributes queries intents per child via composite blame key`() {
+        // App declares two intents, library injects one — each must land in its own
+        // source group, not duplicated like the old container-based fallback did.
+        val sendKey = "intent#action:name:android.intent.action.SEND+data:mimeType:image/*"
+        val viewKey = "intent#action:name:android.intent.action.VIEW+data:scheme:https"
+        val pickKey = "intent#action:name:android.intent.action.PICK"
+
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = emptyList(),
+                intents = listOf(
+                    QueryIntent(actions = listOf("android.intent.action.SEND"), categories = emptyList(),
+                        dataSpecs = listOf("image/*"), blameKey = sendKey),
+                    QueryIntent(actions = listOf("android.intent.action.VIEW"), categories = emptyList(),
+                        dataSpecs = listOf("https://"), blameKey = viewKey),
+                    QueryIntent(actions = listOf("android.intent.action.PICK"), categories = emptyList(),
+                        dataSpecs = emptyList(), blameKey = pickKey),
+                ),
+                providers = emptyList(),
+            ),
+        )
+        val sourceMap = mapOf(
+            sendKey to listOf(":app"),
+            viewKey to listOf(":app"),
+            pickKey to listOf(":sample:module1"),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = sourceMap,
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        val appSection = result.substringAfter("[:app]").substringBefore("[:")
+        val module1Section = result.substringAfter("[:sample:module1]")
+
+        // SEND and VIEW belong to :app
+        assertThat(appSection).contains("action: android.intent.action.SEND")
+        assertThat(appSection).contains("action: android.intent.action.VIEW")
+        assertThat(appSection).doesNotContain("action: android.intent.action.PICK")
+        // PICK belongs to :sample:module1
+        assertThat(module1Section).contains("action: android.intent.action.PICK")
+        assertThat(module1Section).doesNotContain("action: android.intent.action.SEND")
+        assertThat(module1Section).doesNotContain("action: android.intent.action.VIEW")
+        assertThat(result).doesNotContain("[<unresolved>]")
+    }
+
+    @Test
+    fun `buildMergedWithSdk routes intent to unresolved when blame key is missing`() {
+        val unknownKey = "intent#action:name:com.example.UNKNOWN"
+        val manifest = emptyManifest().copy(
+            queries = ManifestQuery(
+                packages = emptyList(),
+                intents = listOf(
+                    QueryIntent(actions = listOf("com.example.UNKNOWN"), categories = emptyList(),
+                        dataSpecs = emptyList(), blameKey = unknownKey),
+                ),
+                providers = emptyList(),
+            ),
+        )
+
+        val result = SourcesContentBuilder.buildMergedWithSdk(
+            manifest = manifest,
+            sourceMap = emptyMap(),
+            projectPath = ":app",
+            flags = enableSingletons(),
+        )
+
+        assertThat(result).contains("[<unresolved>]")
+        val unresolvedSection = result.substringAfter("[<unresolved>]")
+        assertThat(unresolvedSection).contains("intent:")
+        assertThat(unresolvedSection).contains("action: com.example.UNKNOWN")
     }
 
     @Test

--- a/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestQueryTest.kt
+++ b/manifest-shield/src/test/kotlin/io/github/fornewid/gradle/plugins/manifestshield/models/ManifestQueryTest.kt
@@ -21,10 +21,12 @@ internal class ManifestQueryTest {
         val query = ManifestQuery(
             packages = emptyList(),
             intents = listOf(
-                IntentFilterInfo(
+                QueryIntent(
                     actions = listOf("android.intent.action.SEND"),
                     categories = listOf("android.intent.category.DEFAULT"),
                     dataSpecs = listOf("text/plain"),
+                    blameKey = "intent#action:name:android.intent.action.SEND" +
+                        "+category:name:android.intent.category.DEFAULT+data:mimeType:text/plain",
                 ),
             ),
             providers = emptyList(),

--- a/manifest-shield/src/test/resources/test-blame-log-singletons.txt
+++ b/manifest-shield/src/test/resources/test-blame-log-singletons.txt
@@ -26,3 +26,7 @@ profileable
 ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:36:9-45
 activity#com.example.app.MainActivity
 ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:25:9-32:20
+intent#action:name:android.intent.action.SEND+data:mimeType:image/*
+ADDED from /Users/dev/MyApp/app/src/main/AndroidManifest.xml:8:9-12:18
+intent#action:name:android.intent.action.PICK
+ADDED from [com.example:lib:1.0.0] /Users/dev/.gradle/caches/8.10.2/transforms/xyz/transformed/lib-1.0.0/AndroidManifest.xml:5:9-7:18


### PR DESCRIPTION
Closes #74.

## Summary

Fix the false-positive case where libraries co-injecting `<queries><intent>` patterns all collapse under whichever library's `<queries>` container appeared first in the merged blame log. Each intent is now attributed to the source that actually declared it, the same way `<package>` already is.

## Phase 1 verification (no code change)

Confirmed directly against AGP's `manifest-merger-release-report.txt`:

- **`<queries><intent>`** uses a composite blame-log key — `intent#action:name:$action[+category:name:$cat][+data:$attr:$value]` — with the *first non-empty* data attribute (priority order `scheme → host → port → path → pathPrefix → pathPattern → pathSuffix → pathAdvancedPattern → mimeType`). Per-intent attribution is therefore achievable.
- **`<queries><provider>`** is keyed by plain `provider` and AGP rejects multi-source declarations with conflicting authorities at merge time, so a single-source declaration is the only buildable case → existing fallback is already correct, no change required.

## Implementation

- New `QueryIntent` model with `actions`, `categories`, `dataSpecs`, and a synthesized `blameKey`. Distinct from `IntentFilterInfo` (still used by `<activity>` intent-filters) so other call sites are untouched.
- `ManifestVisitor.parseQueryIntent` synthesizes the same composite key AGP uses, walking action → category → data with the data-attribute priority above. `pathSuffix` and `pathAdvancedPattern` (API 31+) are included so newer manifests round-trip.
- `SourcesContentBuilder.addQueriesEntries` resolves `sourceMap[intent.blameKey]` per intent and falls back to `[<unresolved>]` when the parser misses, never to the silent first-source default.

## Test plan

- [x] `BlameLogParserTest` — composite key fixture lookups
- [x] `ManifestVisitorEdgeCaseTest` — synthesized key matches AGP's recorded shape including the first-non-empty-data-attribute rule
- [x] `SourcesContentBuilderTest` — multi-source per-intent attribution and `<unresolved>` fallback
- [x] `ManifestShieldPluginTest` — gradleTest covers app-declared intents end to end
- [x] `:manifest-shield:check` passes locally
- [x] Sample baseline unchanged (`./gradlew manifestShieldBaseline` produces no diff — sample does not use queries)
- [ ] CI green
