### PR TITLE
Upgrade release-drafter to v7.2.1 (Node.js 24 support)

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'fornewid/manifest-shield'
     steps:
-      - uses: release-drafter/release-drafter@v6
+      # v7 runs on Node.js 24 (v6 was on Node 20, removed from runners 2026-09-16)
+      # and adds a `token` input that defaults to `github.token`, so the explicit
+      # `env: GITHUB_TOKEN` block from the v6 setup is no longer needed.
+      - uses: release-drafter/release-drafter@v7.2.1
         with:
           publish: ${{ startsWith(github.ref, 'refs/tags/') }}
           # When publish.yml pushes a tag we want the GitHub Release to be
@@ -26,5 +29,3 @@ jobs:
           # repo with no prior tags).
           tag: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
           name: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #77.

## Summary

Bump `release-drafter/release-drafter` from `@v6` to `@v7.2.1` to clear the Node.js 20 deprecation warning ahead of the 2026-09-16 runtime removal. Also drop the now-redundant `env: GITHUB_TOKEN` block — v7 reads the token from a new `token` input that defaults to `github.token`.

Reference run with the warnings: <https://github.com/fornewid/manifest-shield/actions/runs/25214557316>

## Why this is safe

Verified upstream that none of v7's BREAKING changes affect this repo:

| BREAKING change in v7 | Impact here |
|---|---|
| Drops Node.js 20 — runners require Node 24 | Already on `ubuntu-latest`; v7 declares `runs.using: node24` |
| Autolabeler split into a separate sub-action; `disable-releaser` / `disable-autolabeler` inputs removed | We don't use the autolabeler |
| `include-pre-releases` config removed | Not set in `.github/release-drafter.yml` |
| `references` config removed (use workflow `on:` triggers instead) | We already use `on: push`; no `references` set |
| `array.single()` syntax for autolabeler labels removed | Not relevant; no autolabeler config |

`.github/release-drafter.yml` only sets `name-template`, `tag-template`, and a minimal `template` — no v7-affected fields.

## Open caveats

- **`pull_request_target.*` "is not a known webhook name" warnings** — these are emitted by GHA when validating the action's metadata. They were present on v6 and may persist on v7 (it depends on how upstream now declares its webhook list). They are non-blocking informational warnings; if they remain after merge, this PR still resolves the more important Node 20 deprecation.
- **End-to-end verification will only happen after merge** — release-drafter is triggered by `push` to main and tags, so the new workflow only exercises on the next main push. If anything goes wrong, the most recent draft release will reflect it; revert is a one-line `@v6` restore.

## Test plan

- [x] Verified v7 BREAKING changes against this repo's config and workflow (table above)
- [x] Verified v7's `action.yml` exposes `publish` / `tag` / `name` inputs identically to v6
- [ ] Post-merge: confirm next `Release Drafter` run on main has no `Node.js 20 actions are deprecated` warning and produces an equivalent draft release
